### PR TITLE
Refactor: alias axios to this.$http

### DIFF
--- a/ui/config/index.js
+++ b/ui/config/index.js
@@ -10,15 +10,6 @@ module.exports = {
     // Paths
     assetsSubDirectory: "static",
     assetsPublicPath: "/",
-    proxyTable: {
-      "/api": {
-        target: process.env.API_ROOT,
-        changeOrigin: true,
-        pathRewrite: {
-          "^/api": ""
-        }
-      }
-    },
 
     // Various Dev Server settings
     host: "localhost", // can be overwritten by process.env.HOST

--- a/ui/src/components/pages/Antivirus.vue
+++ b/ui/src/components/pages/Antivirus.vue
@@ -118,7 +118,6 @@
   </div>
 </template>
 <script>
-import axios from "axios"
 import Loader from "@/components/elements/Loader"
 import Copy from "@/components/elements/Copy"
 
@@ -145,8 +144,8 @@ export default {
   },
   mounted() {
     // replace route params with props
-    axios
-      .get(`/api/v1/files/${this.$route.params.hash}/`)
+    this.$http
+      .get(`/v1/files/${this.$route.params.hash}/`)
       .then((data) => {
         this.showLoader = false
         if (!data.data.multiav) {

--- a/ui/src/components/pages/ForgotPassword.vue
+++ b/ui/src/components/pages/ForgotPassword.vue
@@ -54,7 +54,6 @@
 
 <script>
 import { required, email } from "vuelidate/lib/validators"
-import axios from "axios"
 import Notification from "@/components/elements/Notification"
 export default {
   data() {
@@ -78,7 +77,7 @@ export default {
         this.errored = true
         this.errorMessage = "Please enter a valid email address"
       } else {
-        axios
+        this.$http
           .delete("/api/v1/users/password/", {
             data: {
               email: this.email,

--- a/ui/src/components/pages/Login.vue
+++ b/ui/src/components/pages/Login.vue
@@ -116,9 +116,9 @@
 <script>
 import { required, helpers } from "vuelidate/lib/validators"
 import Notification from "@/components/elements/Notification"
-import axios from "axios"
 
 const usernameValid = helpers.regex("username", /^[a-zA-Z0-9]{1,20}$/)
+const defaultErrorMessage = `Something went wrong, please try again!`
 
 export default {
   data() {
@@ -149,8 +149,8 @@ export default {
         this.errorMessage =
           "Please correct all highlighted errors and try again"
       } else {
-        axios
-          .post("/api/v1/auth/login/", {
+        this.$http
+          .post("/v1/auth/login/", {
             username: this.username,
             password: this.password,
           })
@@ -164,10 +164,16 @@ export default {
               }
             }
           })
-          .catch((error) => {
-            this.errored = true
-            this.errorMessage = error.response.data.verbose_msg || `Something went wrong, please try again!`
-          })
+          .catch(
+            ({
+              response: {
+                data: { verbose_msg: verboseMsg = defaultErrorMessage } = {},
+              } = {},
+            } = {}) => {
+              this.errored = true
+              this.errorMessage = verboseMsg
+            },
+          )
       }
     },
     close() {

--- a/ui/src/components/pages/ResetPassword.vue
+++ b/ui/src/components/pages/ResetPassword.vue
@@ -115,7 +115,6 @@
 
 <script>
 import { required, minLength, sameAs } from "vuelidate/lib/validators"
-import axios from "axios"
 import queryString from "query-string"
 import Notification from "@/components/elements/Notification"
 
@@ -156,8 +155,8 @@ export default {
           paramsSerializer: (params) =>
             queryString.stringify(params, { arrayFormat: "bracket" }),
         }
-        axios
-          .post("/api/v1/users/password/", postData, axiosConfig)
+        this.$http
+          .post("/v1/users/password/", postData, axiosConfig)
           .then((response) => {
             this.succeeded = true
             this.errored = false

--- a/ui/src/components/pages/Signup.vue
+++ b/ui/src/components/pages/Signup.vue
@@ -148,7 +148,6 @@ import {
   helpers,
   sameAs,
 } from "vuelidate/lib/validators"
-import axios from "axios"
 import Notification from "@/components/elements/Notification"
 
 const usernameValid = helpers.regex("username", /^[a-zA-Z0-9]{1,20}$/)
@@ -176,8 +175,8 @@ export default {
         this.errorMessage =
           "Please correct all highlighted errors and try again"
       } else {
-        axios
-          .post("/api/v1/users/", {
+        this.$http
+          .post("/v1/users/", {
             username: this.username,
             email: this.email,
             password: this.password,

--- a/ui/src/components/pages/Strings.vue
+++ b/ui/src/components/pages/Strings.vue
@@ -88,7 +88,6 @@
   </div>
 </template>
 <script>
-import axios from "axios"
 import Loader from "@/components/elements/Loader"
 
 export default {
@@ -114,8 +113,8 @@ export default {
     },
   },
   created() {
-    axios
-      .get(`/api/v1/files/${this.$route.params.hash}/`)
+    this.$http
+      .get(`/v1/files/${this.$route.params.hash}/`)
       .then((data) => {
         this.showLoader = false
         this.strings = data.data.strings

--- a/ui/src/components/pages/Summary.vue
+++ b/ui/src/components/pages/Summary.vue
@@ -71,7 +71,6 @@
   </div>
 </template>
 <script>
-import axios from "axios"
 import Loader from "@/components/elements/Loader"
 import Copy from "@/components/elements/Copy"
 
@@ -116,7 +115,7 @@ export default {
     },
   },
   mounted() {
-    axios.get(`/api/v1/files/${this.$route.params.hash}/`).then((data) => {
+    this.$http.get(`/v1/files/${this.$route.params.hash}/`).then((data) => {
       this.showLoader = false
 
       data.data["sha-1"] = data.data.sha1

--- a/ui/src/components/pages/Upload.vue
+++ b/ui/src/components/pages/Upload.vue
@@ -49,7 +49,6 @@
 import Tabs from "@/components/elements/Tabs"
 import Tab from "@/components/elements/Tab"
 import Notification from "@/components/elements/Notification"
-import axios from "axios"
 import DropZone from "@/components/elements/DropZone"
 import ProgressTracker, { StepItem } from "vue-bulma-progress-tracker"
 
@@ -115,8 +114,8 @@ export default {
               hashHex += hex
             }
             // hash hexadecimal has been calculated successfully
-            axios
-              .get(`/api/v1/files/${hashHex}/`)
+            this.$http
+              .get(`/v1/files/${hashHex}/`)
               .then((response) => {
                 // file exists
                 this.$router.push(`summary/${hashHex}`)
@@ -125,8 +124,8 @@ export default {
                 this.ongoingStep = step.UPLOADED
                 const formData = new FormData()
                 formData.append("file", file)
-                axios
-                  .post("/api/v1/files/", formData, {
+                this.$http
+                  .post("/v1/files/", formData, {
                     headers: {
                       "Content-Type": "multipart/form-data",
                     },
@@ -155,8 +154,8 @@ export default {
       reader.readAsArrayBuffer(file)
     },
     fetchStatus(hashHex) {
-      axios
-        .get(`/api/v1/files/${hashHex}/`)
+      this.$http
+        .get(`/v1/files/${hashHex}/`)
         .then((response) => {
           const status = response.data.status
           // change ongoingStep according to status

--- a/ui/src/components/partials/Header.vue
+++ b/ui/src/components/partials/Header.vue
@@ -72,7 +72,6 @@
 
 <script>
 import { store } from "../../store.js"
-import axios from "axios"
 import Notification from "@/components/elements/Notification"
 export default {
   name: "Header",
@@ -116,8 +115,8 @@ export default {
       this.notifActive = false
     },
     searchByHash() {
-      axios
-        .get(`/api/v1/files/${this.hash}/`, {
+      this.$http
+        .get(`/v1/files/${this.hash}/`, {
           validateStatus: (status) => status === 200,
         })
         .then(() => {

--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -10,7 +10,10 @@ import Unauthenticated from "./layouts/Unauthenticated.vue"
 
 import Vuelidate from "vuelidate"
 
+import axios from "axios"
+
 import VueCookie from "vue-cookie"
+
 Vue.use(Vuelidate)
 Vue.use(VueCookie)
 
@@ -70,6 +73,10 @@ Vue.directive("focus", {
 })
 
 Vue.config.productionTip = false
+
+Vue.prototype.$http = axios.create({
+  baseURL: process.env.API_ROOT,
+})
 
 /* eslint-disable no-new */
 new Vue({


### PR DESCRIPTION
This PR aims to move `axios` out of individual components and instead add it to Vue prototype, so it's available to all components via `this.$http`

it allowed to set the base url following the environment we're in, through the available `.env` file, and also get rid of api proxying in dev

@Akhouad thanks for the suggestion 🙌🏼