### PR TITLE
various improvements to rich header parsing

### DIFF
--- a/pkg/peparser/cmd/main.go
+++ b/pkg/peparser/cmd/main.go
@@ -56,9 +56,9 @@ func parse(filename string) {
 	// 	}
 	// }
 
-	var buff []byte
-	buff, err = json.Marshal(pe.RichHeader)
-	fmt.Print(prettyPrint(buff))
+	// var buff []byte
+	// buff, err = json.Marshal(pe.RichHeader)
+	// fmt.Print(prettyPrint(buff))
 	pe.Close()
 	// if err == nil {
 	// 	if pe.IsDLL() {

--- a/pkg/peparser/go.sum
+++ b/pkg/peparser/go.sum
@@ -1,6 +1,5 @@
 github.com/edsrzf/mmap-go v1.0.0 h1:CEBF7HpRnUCSJgGUb5h1Gm7e3VkmVDrR8lvWVLtrOFw=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
-github.com/saferwall/saferwall v0.0.1 h1:9IH1YsVRgOwgEsCH5DhWCUQNYTPWTJyRhira75CczHY=
 go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1 h1:A/5uWzF44DlIgdm/PQFwfMkW0JX+cIcQi/SwLAmZP5M=
 go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1/go.mod h1:SNgMg+EgDFwmvSmLRTNKC5fegJjB7v23qTQ0XLGUNHk=
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f h1:gWF768j/LaZugp8dyS4UwsslYCYz9XgFxvlgsn0n9H8=

--- a/pkg/peparser/helper.go
+++ b/pkg/peparser/helper.go
@@ -33,44 +33,51 @@ var (
 	ErrDOSMagicNotFound = errors.New("DOS Header magic not found")
 
 	// ErrInvalidElfanewValue is returned when e_lfanew is larger than file size.
-	ErrInvalidElfanewValue = errors.New("Invalid e_lfanew value, probably not a PE file")
+	ErrInvalidElfanewValue = errors.New(
+		"Invalid e_lfanew value, probably not a PE file")
 
 	// ErrImageOS2SignatureFound is returned when signature is for a NE file.
-	ErrImageOS2SignatureFound = errors.New("Not a valid PE signature. Probably a NE file")
+	ErrImageOS2SignatureFound = errors.New(
+		"Not a valid PE signature. Probably a NE file")
 
 	// ErrImageOS2LESignatureFound is returned when signature is for a LE file.
-	ErrImageOS2LESignatureFound = errors.New("Not a valid PE signature. Probably an LE file")
+	ErrImageOS2LESignatureFound = errors.New(
+		"Not a valid PE signature. Probably an LE file")
 
 	// ErrImageVXDSignatureFound is returned when signature is for a NX file.
-	ErrImageVXDSignatureFound = errors.New("Not a valid PE signature. Probably an LX file")
+	ErrImageVXDSignatureFound = errors.New(
+		"Not a valid PE signature. Probably an LX file")
 
 	// ErrImageTESignatureFound is returned when signature is for a TE file.
-	ErrImageTESignatureFound = errors.New("Not a valid PE signature. Probably a TE file")
+	ErrImageTESignatureFound = errors.New(
+		"Not a valid PE signature. Probably a TE file")
 
 	// ErrImageNtSignatureNotFound is returned when PE magic signature is not found.
-	ErrImageNtSignatureNotFound = errors.New("Not a valid PE signature. Magic not found")
+	ErrImageNtSignatureNotFound = errors.New(
+		"Not a valid PE signature. Magic not found")
 
 	// ErrImageNtOptionalHeaderMagicNotFound is returned when optional header
 	// magic is different from PE32/PE32+.
-	ErrImageNtOptionalHeaderMagicNotFound = errors.New(`Not a valid PE signature.
-	 Optional Header magic not found`)
+	ErrImageNtOptionalHeaderMagicNotFound = errors.New(
+		"Not a valid PE signature. Optional Header magic not found")
 
-	// ErrImageBaseNotAligned is reported when the image base is not aligned to 64 K.
-	ErrImageBaseNotAligned = errors.New("Corrupt PE file. Image base not aligned to 64 K")
+	// ErrImageBaseNotAligned is reported when the image base is not aligned to 64K.
+	ErrImageBaseNotAligned = errors.New(
+		"Corrupt PE file. Image base not aligned to 64 K")
 
 	// AnoImageBaseOverflow is reported when the image base + SizeOfImage is
 	// larger than 80000000h/FFFF080000000000h in PE32/P32+.
-	AnoImageBaseOverflow = "Image base is overflow"
+	AnoImageBaseOverflow = "Image base beyong allowed address"
 
 	// ErrInvalidSectionFileAlignment is reported when section alignment is less than a
 	// PAGE_SIZE and section alignement != file alignment.
-	ErrInvalidSectionFileAlignment = errors.New(`Corrupt PE file. Section alignment
-	 is less than a PAGE_SIZE and section alignement != file alignment`)
+	ErrInvalidSectionFileAlignment = errors.New("Corrupt PE file. Section " + 
+	"alignment is less than a PAGE_SIZE and section alignement != file alignment")
 
-	// ErrInvalidSizeOfImage is reported when SizeOfImage is nota multiple of
+	// AnoInvalidSizeOfImage is reported when SizeOfImage is not multiple of
 	// SectionAlignment.
-	ErrInvalidSizeOfImage = errors.New(`Invalid SizeOfImage value, should be
-	 multiple of SectionAlignment`)
+	AnoInvalidSizeOfImage = "Invalid SizeOfImage value, should be multiple " +
+	 "of SectionAlignment"
 )
 
 // Max returns the larger of x or y.

--- a/pkg/peparser/helper.go
+++ b/pkg/peparser/helper.go
@@ -454,65 +454,6 @@ func (pe *File)IsEXE() bool {
 	return true
 }
 
-
-
-// PrettySectionFlags returns the string representations of the
-// `Flags` field of section header.
-func (pe *File) PrettySectionFlags(curSectionFlag uint32) []string {
-	var values []string
-
-	sectionFlags := map[uint32]string{
-		ImageScnReserved1:            "Reserved1",
-		ImageScnReserved2:            "Reserved2",
-		ImageScnReserved3:            "Reserved3",
-		ImageScnReserved4:            "Reserved4",
-		ImageScnTypeNoPad:            "No Padd",
-		ImageScnReserved5:            "Reserved5",
-		ImageScnCntCode:              "Contains Code",
-		ImageScnCntInitializedData:   "Initialized Data",
-		ImageScnCntUninitializedData: "Uninitialized Data",
-		ImageScnLnkOther:             "Lnk Other",
-		ImageScnLnkInfo:              "Lnk Info",
-		ImageScnReserved6:            "Reserved6",
-		ImageScnLnkRemove:            "LnkRemove",
-		ImageScnLnkComdat:            "LnkComdat",
-		ImageScnGpRel:                "GpReferenced",
-		ImageScnMemPurgeable:         "Purgeable",
-		ImageScnMemLocked:            "Locked",
-		ImageScnMemPreload:           "Preload",
-		ImageScnAlign1Bytes:          "Align1Bytes",
-		ImageScnAlign2Bytes:          "Align2Bytes",
-		ImageScnAlign4Bytes:          "Align4Bytes",
-		ImageScnAlign8Bytes:          "Align8Bytes",
-		ImageScnAlign16Bytes:         "Align16Bytes",
-		ImageScnAlign32Bytes:         "Align32Bytes",
-		ImageScnAlign64Bytes:         "Align64Bytes",
-		ImageScnAlign128Bytes:        "Align128Bytes",
-		ImageScnAlign256Bytes:        "Align265Bytes",
-		ImageScnAlign512Bytes:        "Align512Bytes",
-		ImageScnAlign1024Bytes:       "Align1024Bytes",
-		ImageScnAlign2048Bytes:       "Align2048Bytes",
-		ImageScnAlign4096Bytes:       "Align4096Bytes",
-		ImageScnAlign8192Bytes:       "Align8192Bytes",
-		ImageScnLnkMRelocOvfl:        "ExtendedReloc",
-		ImageScnMemDiscardable:       "Discardable",
-		ImageScnMemNotCached:         "NotCached",
-		ImageScnMemNotPaged:          "NotPaged",
-		ImageScnMemShared:            "Shared",
-		ImageScnMemExecute:           "Executable",
-		ImageScnMemRead:              "Readable",
-		ImageScnMemWrite:             "Writable",
-	}
-
-	for k, s := range sectionFlags {
-		if k&curSectionFlag != 0 {
-			values = append(values, s)
-		}
-	}
-
-	return values
-}
-
 // padOrTrim returns (size) bytes from input (bb)
 // Short bb gets zeros prefixed, Long bb gets left/MSB bits trimmed
 func padOrTrim(bb []byte, size int) []byte {

--- a/pkg/peparser/imports.go
+++ b/pkg/peparser/imports.go
@@ -259,7 +259,7 @@ func (pe *File) getImportTable32(rva uint32, maxLen uint32, isOldDelayImport boo
 		// 5945bb6f0ac879ddf61b1c284f3b8d20c06b228e75ae4f571fa87f5b9512902c
 		if thunk.AddressOfData >= startRVA && thunk.AddressOfData <= rva {
 			log.Printf("Error parsing the import table. "+
-				"AddressOfData overlaps with THUNK_DATA for THUNK at:\n  "+
+				"AddressOfData overlaps with THUNK_DATA for THUNK at: "+
 				"RVA 0x%x", rva)
 			break
 		}
@@ -378,7 +378,7 @@ func (pe *File) getImportTable64(rva uint32, maxLen uint32,
 		if thunk.AddressOfData >= uint64(startRVA) &&
 			thunk.AddressOfData <= uint64(rva) {
 			log.Printf("Error parsing the import table. "+
-				"AddressOfData overlaps with THUNK_DATA for THUNK at:\n  "+
+				"AddressOfData overlaps with THUNK_DATA for THUNK at: "+
 				"RVA 0x%x", rva)
 			break
 		}

--- a/pkg/peparser/ntheader.go
+++ b/pkg/peparser/ntheader.go
@@ -397,10 +397,11 @@ func (pe *File) ParseNTHeader() (err error) {
 		pe.Anomalies = append(pe.Anomalies, AnoImageBaseOverflow)
 	}
 
-	// SizeOfImage must be a multiple of the section alignment.
+	// The msdn states that SizeOfImage must be a multiple of the section 
+	// alignment. This is not true though. Adding it as anomaly.
 	if (pe.Is32 && oh32.SizeOfImage%oh32.SectionAlignment != 0) ||
 		(pe.Is64 && oh64.SizeOfImage%oh64.SectionAlignment != 0) {
-		return ErrInvalidSizeOfImage
+		pe.Anomalies = append(pe.Anomalies, AnoInvalidSizeOfImage)
 	}
 
 	return nil

--- a/pkg/peparser/pe.go
+++ b/pkg/peparser/pe.go
@@ -76,10 +76,10 @@ const (
 	ImageSubsystemNative                 = 1  // Device drivers and native Windows processes
 	ImageSubsystemWindowsGUI             = 2  // The Windows graphical user interface (GUI) subsystem.
 	ImageSubsystemWindowsCUI             = 3  // The Windows character subsystem
-	ImageSubsystemOS2CUI              = 5  // The OS/2 character subsystem.
+	ImageSubsystemOS2CUI                 = 5  // The OS/2 character subsystem.
 	ImageSubsystemPosixCUI               = 7  // The Posix character subsystem.
 	ImageSubsystemNativeWindows          = 8  // Native Win9x driver
-	ImageSubsystemWindowsCEGUI             = 9  // Windows CE
+	ImageSubsystemWindowsCEGUI           = 9  // Windows CE
 	ImageSubsystemEFIApplication         = 10 // An Extensible Firmware Interface (EFI) application
 	ImageSubsystemEFIBootServiceDriver   = 11 // An EFI driver with boot services
 	ImageSubsystemEFIRuntimeDriver       = 12 // An EFI driver with run-time services

--- a/pkg/peparser/section.go
+++ b/pkg/peparser/section.go
@@ -288,7 +288,7 @@ func (pe *File) ParseSectionHeader() (err error) {
 	return nil
 }
 
-// NameString returns string represntation of a ImageSectionHeader.Name field.
+// NameString returns string representation of a ImageSectionHeader.Name field.
 func (section *ImageSectionHeader) NameString() string {
 	return fmt.Sprintf("%s", section.Name)
 }
@@ -383,4 +383,62 @@ func (s byPointerToRawData) Len() int      { return len(s) }
 func (s byPointerToRawData) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s byPointerToRawData) Less(i, j int) bool {
 	return s[i].PointerToRawData < s[j].PointerToRawData
+}
+
+
+// PrettySectionFlags returns the string representations of the
+// `Flags` field of section header.
+func (pe *File) PrettySectionFlags(curSectionFlag uint32) []string {
+	var values []string
+
+	sectionFlags := map[uint32]string{
+		ImageScnReserved1:            "Reserved1",
+		ImageScnReserved2:            "Reserved2",
+		ImageScnReserved3:            "Reserved3",
+		ImageScnReserved4:            "Reserved4",
+		ImageScnTypeNoPad:            "No Padd",
+		ImageScnReserved5:            "Reserved5",
+		ImageScnCntCode:              "Contains Code",
+		ImageScnCntInitializedData:   "Initialized Data",
+		ImageScnCntUninitializedData: "Uninitialized Data",
+		ImageScnLnkOther:             "Lnk Other",
+		ImageScnLnkInfo:              "Lnk Info",
+		ImageScnReserved6:            "Reserved6",
+		ImageScnLnkRemove:            "LnkRemove",
+		ImageScnLnkComdat:            "LnkComdat",
+		ImageScnGpRel:                "GpReferenced",
+		ImageScnMemPurgeable:         "Purgeable",
+		ImageScnMemLocked:            "Locked",
+		ImageScnMemPreload:           "Preload",
+		ImageScnAlign1Bytes:          "Align1Bytes",
+		ImageScnAlign2Bytes:          "Align2Bytes",
+		ImageScnAlign4Bytes:          "Align4Bytes",
+		ImageScnAlign8Bytes:          "Align8Bytes",
+		ImageScnAlign16Bytes:         "Align16Bytes",
+		ImageScnAlign32Bytes:         "Align32Bytes",
+		ImageScnAlign64Bytes:         "Align64Bytes",
+		ImageScnAlign128Bytes:        "Align128Bytes",
+		ImageScnAlign256Bytes:        "Align265Bytes",
+		ImageScnAlign512Bytes:        "Align512Bytes",
+		ImageScnAlign1024Bytes:       "Align1024Bytes",
+		ImageScnAlign2048Bytes:       "Align2048Bytes",
+		ImageScnAlign4096Bytes:       "Align4096Bytes",
+		ImageScnAlign8192Bytes:       "Align8192Bytes",
+		ImageScnLnkMRelocOvfl:        "ExtendedReloc",
+		ImageScnMemDiscardable:       "Discardable",
+		ImageScnMemNotCached:         "NotCached",
+		ImageScnMemNotPaged:          "NotPaged",
+		ImageScnMemShared:            "Shared",
+		ImageScnMemExecute:           "Executable",
+		ImageScnMemRead:              "Readable",
+		ImageScnMemWrite:             "Writable",
+	}
+
+	for k, s := range sectionFlags {
+		if k&curSectionFlag != 0 {
+			values = append(values, s)
+		}
+	}
+
+	return values
 }


### PR DESCRIPTION
- threat SizeOfImage must be a multiple of the section alignment as an anomaly and not a error.
- better error checking when rich header signature was found, but could not locate DanS magic.
- treat rich header non padding leading zeros as warning, and keep parsing.
- calculate rich header checksum