### PR TITLE
[build] Fix Minikube Deployements

### DIFF
--- a/build/mk/minikube.mk
+++ b/build/mk/minikube.mk
@@ -23,4 +23,5 @@ else
 endif
 	kubectl version
 	minikube status
+	sudo minikube addons enable ingress
 

--- a/deployments/saferwall/Chart.lock
+++ b/deployments/saferwall/Chart.lock
@@ -1,13 +1,10 @@
 dependencies:
 - name: minio
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 5.0.24
+  version: 5.0.31
 - name: couchbase-operator
   repository: https://couchbase-partners.github.io/helm-charts/
-  version: 0.1.2
-- name: couchbase-cluster
-  repository: https://couchbase-partners.github.io/helm-charts/
-  version: 0.1.2
+  version: 2.0.1
 - name: efs-provisioner
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.11.0
@@ -22,15 +19,15 @@ dependencies:
   version: 1.36.3
 - name: filebeat
   repository: https://helm.elastic.co
-  version: 7.6.2
+  version: 7.8.0
 - name: elasticsearch
   repository: https://helm.elastic.co
-  version: 7.6.2
+  version: 7.8.0
 - name: kibana
   repository: https://helm.elastic.co
-  version: 7.6.2
+  version: 7.8.0
 - name: prometheus-operator
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 8.13.3
-digest: sha256:e1057e3d162cbbe7d2c716968cb916843b5ba1c50b29bffec29f980d2c3066e3
-generated: "2020-07-16T19:40:18.289599087+10:00"
+  version: 9.1.0
+digest: sha256:a70239df8f0501a914efd10139d37ff4e279ed625c3d8a78b7d191e967a84af4
+generated: "2020-07-21T11:03:32.744699327+10:00"

--- a/deployments/saferwall/Chart.yaml
+++ b/deployments/saferwall/Chart.yaml
@@ -12,17 +12,13 @@ maintainers:
       email: admin@saferwall.com
 dependencies:
     - name: minio
-      version: 5.0.24
+      version: 5.0.31
       repository: https://kubernetes-charts.storage.googleapis.com/
       condition: minio.enabled
     - name: couchbase-operator
-      version: 0.1.2
+      version: 2.0.1
       repository: https://couchbase-partners.github.io/helm-charts/
       condition: couchbase-operator.enabled
-    - name: couchbase-cluster
-      version: 0.1.2
-      repository: https://couchbase-partners.github.io/helm-charts/
-      condition: couchbase-cluster.enabled
     - name: efs-provisioner
       version: 0.11.0
       repository: https://kubernetes-charts.storage.googleapis.com/
@@ -40,18 +36,18 @@ dependencies:
       repository: https://kubernetes-charts.storage.googleapis.com/
       condition: nginx-ingress.enabled
     - name: filebeat
-      version: 7.6.2
+      version: 7.8.0
       repository: https://helm.elastic.co
       condition: filebeat.enabled
     - name: elasticsearch
-      version: 7.6.2
+      version: 7.8.0
       repository: https://helm.elastic.co
       condition: elasticsearch.enabled
     - name: kibana
-      version: 7.6.2
+      version: 7.8.0
       repository: https://helm.elastic.co
       condition: kibana.enabled
     - name: prometheus-operator
-      version: 8.13.3
+      version: 9.1.0
       repository: https://kubernetes-charts.storage.googleapis.com/
       condition: prometheus-operator.enabled

--- a/deployments/saferwall/files/backend-conf.toml
+++ b/deployments/saferwall/files/backend-conf.toml
@@ -1,7 +1,7 @@
 # This file needs to be edited !
 
 [ui]
-address = "https://company.com"
+address = "http://mysaferwall.com"
 
 [app]
 address = ":8080"
@@ -11,7 +11,7 @@ max_file_size = 64000000 # 64MB
 max_avatar_file_size = 100000 # 100KB
 admin_user = "Administrator"
 admin_pwd = "password"
-admin_email = "admin@company.com"
+admin_email = "admin@mysaferwall.com"
 
 [db]
 server = '{{ printf "couchbase://%s-couchbase-cluster-srv" .Release.Name }}'
@@ -36,7 +36,7 @@ signkey = "jwt_secret_auth_key"
 [smtp]
 server = "smtp.gmail.com"
 port = 465
-user =  "noreply@company.com"
+user =  "noreply@mysaferwall.com"
 password = "password"
-identity =  "CompanyIdentify"
-sender =  "noreply@company.com"
+identity = "CompanyIdentify"
+sender = "noreply@mysaferwall.com"

--- a/deployments/saferwall/templates/ingress.yaml
+++ b/deployments/saferwall/templates/ingress.yaml
@@ -1,20 +1,23 @@
-{{- if index .Values "cert-manager" "enabled" -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "saferwall.fullname" . }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/client-body-buffer-size: "64M"
     nginx.ingress.kubernetes.io/proxy-body-size: "64M"
+    {{- if index .Values "cert-manager" "enabled" -}}
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    {{- end }}
 spec:
+  {{- if index .Values "cert-manager" "enabled" -}}
   tls:
   - hosts:
     - {{ .Values.frontendDomainName }}
     - {{ .Values.backendDomainName }}
     - {{ .Values.websiteDomainName }}
     secretName: {{ include "saferwall.fullname" . }}-tls
+  {{- end }}
   rules:
   - host: {{ .Values.frontendDomainName }}
     http:
@@ -30,6 +33,7 @@ spec:
         backend:
           serviceName: {{ include "saferwall.backend.fullname" . }}
           servicePort: {{ .Values.backend.service.port }}
+{{- if .Values.website.enabled -}}
   - host: {{ .Values.websiteDomainName }}
     http:
       paths:

--- a/deployments/saferwall/templates/ingress.yaml
+++ b/deployments/saferwall/templates/ingress.yaml
@@ -19,14 +19,14 @@ spec:
     secretName: {{ include "saferwall.fullname" . }}-tls
   {{- end }}
   rules:
-  - host: {{ .Values.frontendDomainName }}
+  - host: {{ .Values.global.frontendDomainName }}
     http:
       paths:
       - path: /
         backend:
           serviceName: {{ include "saferwall.frontend.fullname" . }}
           servicePort: {{ .Values.frontend.service.port }}
-  - host: {{ .Values.backendDomainName }}
+  - host: {{ .Values.global.backendDomainName }}
     http:
       paths:
       - path: /
@@ -34,7 +34,7 @@ spec:
           serviceName: {{ include "saferwall.backend.fullname" . }}
           servicePort: {{ .Values.backend.service.port }}
 {{- if .Values.website.enabled -}}
-  - host: {{ .Values.websiteDomainName }}
+  - host: {{ .Values.global.websiteDomainName }}
     http:
       paths:
       - path: /

--- a/deployments/saferwall/values.yaml
+++ b/deployments/saferwall/values.yaml
@@ -3,7 +3,7 @@
 # https://github.com/saferwall/saferwall
 #
 
-## Deploy environment label, e.g. local, aws
+## Deploy environment label, e.g. local, aws.
 ##
 global:
   deployEnv: local
@@ -84,77 +84,249 @@ prometheus-operator:
   enabled: false
 
 ####### COUCHBASE #########
-couchbase-cluster:
-  enabled: false
-  couchbaseCluster:
-    create: true
-    authSecretOverride: "cb-admin-secret"
-    baseImage: "couchbase/server"
-    version: "enterprise-6.0.1"
-    exposeAdminConsole: true
-    adminConsoleServices:
-      - data
-    exposedFeatures: []
+couchbase-operator:
+  enabled: true
+
+  # Select what to install
+  install:
+    # install the couchbase operator
+    couchbaseOperator: true
+    # install the admission controller
+    admissionController: true
+    # install couchbase cluster
+    couchbaseCluster: true
+    # install sync gateway
+    syncGateway: false
+
+  # couchbaseOperator is the controller for couchbase cluster
+  couchbaseOperator:
+    # name of the couchbase operator
+    name: "couchbase-operator"
+    # image config
+    image:
+      repository: couchbase/operator
+      tag: 2.0.1
+    imagePullPolicy: IfNotPresent
+    # imagePullSecrets is an optional list of references to secrets  to use for pulling images
+    imagePullSecrets: []
+    # additional command arguments will be translated to `--key=value`
+    commandArgs:
+      # pod creation timeout
+      pod-create-timeout: 10m
+    # resources of couchbase-operator
+    resources: {}
+    # nodeSelector for couchbase-operator pod assignment
+    # Ref: https://kubernetes.io/docs/user-guide/node-selection/
+    nodeSelector: {}
+    # tolerations of pod match nodes with corresponding taints
+    tolerations: []
+
+  # Default values for couchbase-cluster
+  cluster:
+    # name of the cluster. defaults to name of chart release
+    name:
+    # image is the base couchbase image and version of the couchbase cluster
+    image: "couchbase/server:6.5.1"
+    security:
+      # adminSecret is name of secret to use instead of using
+      # the default secret with username and password specified above
+      adminSecret: "cb-admin-secret"
+      rbac:
+        managed: true
+      ldap: {}
+    # networking options
+    networking:
+      # Option to expose admin console
+      exposeAdminConsole: true
+      # Option to expose admin console
+      adminConsoleServices:
+        - data
+      # Specific services to use when exposing ui
+      exposedFeatures:
+        - client
+        - xdcr
+      # Defines how the admin console service is exposed.
+      # Allowed values are NodePort and LoadBalancer.
+      # If this field is LoadBalancer then you must also define a spec.dns.domain.
+      adminConsoleServiceType: NodePort
+      # Defines how the per Couchbase node ports are exposed.
+      # Allowed values are NodePort and LoadBalancer.
+      # If this field is LoadBalancer then you must also define a spec.dns.domain.
+      exposedFeatureServiceType: NodePort
+      # The dynamic DNS configuration to use when exposing services
+      dns:
+      # Custom map of annotations to be added to console and per-pod (exposed feature) services
+      serviceAnnotations: {}
+      # The Couchbase cluster tls configuration (auto-generated)
+      tls:
+    # The retention period that log volumes are kept for after their associated pods have been deleted.
+    logRetentionTime: 604800s
+    # The maximum number of log volumes that can be kept after their associated pods have been deleted.
+    logRetentionCount: 20
+    # xdcr defines remote clusters and replications to them.
+    xdcr:
+      # managed defines whether the Operator should manage XDCR remote clusters
+      managed: false
+      # remoteClusters contains references to any remote clusters to replicate to
+      remoteClusters:
+    # backup defines values for automated backup.
+    backup:
+      # managed determines whether Automated Backup is enabled
+      managed: true
+      # image used by the Operator to perform backup or restore
+      image: couchbase/operator-backup:6.5.1
+      # optional service account to use when performing backups
+      # service account will be created if it does not exist
+      serviceAccountName:
+    # defines integration with third party monitoring sofware
+    monitoring:
+      prometheus:
+        # defines whether Prometheus metric collection is enabled
+        enabled: false
+        # image used by the Operator to perform metric collection
+        # (injected as a "sidecar" in each Couchbase Server Pod)
+        image: couchbase/exporter:1.0.1
+        # Optional Kubernetes secret that clients use to access Prometheus metrics
+        authorizationSecret:
+    # Cluster wide settings for nodes and services
     cluster:
-      dataServiceMemoryQuota: 512
-      indexServiceMemoryQuota: 512
-      searchServiceMemoryQuota: 512
-      eventingServiceMemoryQuota: 512
-      analyticsServiceMemoryQuota: 1024
+      # The amount of memory that should be allocated to the data service
+      dataServiceMemoryQuota: 512Mi
+      # The amount of memory that should be allocated to the index service
+      indexServiceMemoryQuota: 512Mi
+      # The amount of memory that should be allocated to the search service
+      searchServiceMemoryQuota: 512Mi
+      # The amount of memory that should be allocated to the eventing service
+      eventingServiceMemoryQuota: 512Mi
+      # The amount of memory that should be allocated to the analytics service
+      analyticsServiceMemoryQuota: 1Gi
+      # The index storage mode to use for secondary indexing
       indexStorageSetting: memory_optimized
-      autoFailoverTimeout: 120
+      # Timeout that expires to trigger the auto failover.
+      autoFailoverTimeout: 120s
+      # The number of failover events we can tolerate
       autoFailoverMaxCount: 3
+      # Whether to auto failover if disk issues are detected
       autoFailoverOnDataDiskIssues: true
-      autoFailoverOnDataDiskIssuesTimePeriod: 120
-      autoFailoverServerGroup: false
+      # How long to wait for transient errors before failing over a faulty disk
+      autoFailoverOnDataDiskIssuesTimePeriod: 120s
+      # configuration of global Couchbase auto-compaction settings.
+      autoCompaction:
+        # amount of fragmentation allowed in persistent database [2-100]
+        databaseFragmentationThreshold:
+          percent: 30
+          size: 1Gi
+        # amount of fragmentation allowed in persistent view files [2-100]
+        viewFragmentationThreshold:
+          percent: 30
+          size: 1Gi
+        # whether auto-compaction should be performed in parallel
+        parallelCompaction: false
+        # how frequently tombstones may be purged
+        tombstonePurgeInterval: 72h
+        # optional window when an auto-compaction may start (uncomment below)
+        timeWindow: {}
+        # start: 02:00
+        # end: 06:00
+        # abortCompactionOutsideWindow: true
+
+    # configuration of logging functionality
+    # for use in conjuction with logs persistent volume mount
+    logging:
+      # retention period that log volumes are kept after pods have been deleted
       logRetentionTime: 604800s
+      # the maximum number of log volumes that can be kept after pods have been deleted
       logRetentionCount: 20
+    # kubernetes security context applied to pods
+    securityContext:
+      # fsGroup of persistent volume mount
+      fsGroup: 1000
+    # cluster buckets
     buckets:
-      files:
-        name: files
-        type: couchbase
-        memoryQuota: 128
-        replicas: 1
-        ioPriority: high
-        evictionPolicy: fullEviction
-        conflictResolution: seqno
-        enableFlush: true
-        enableIndexReplica: false
-      users:
-        name: users
-        type: couchbase
-        memoryQuota: 128
-        replicas: 1
-        ioPriority: high
-        evictionPolicy: fullEviction
-        conflictResolution: seqno
-        enableFlush: true
-        enableIndexReplica: false
+      # Managed defines whether buckets are managed by us or the clients.
+      managed: true
     servers:
-      all_services:
+      # Name for the server configuration. It must be unique.
+      default:
+        # Size of the couchbase cluster.
         size: 3
+        # The services to run on nodes
         services:
           - data
           - index
           - query
           - search
-          - eventing
           - analytics
+          - eventing
+        # volume claims to use for persistent storage
+        volumeMounts: {}
+        # ServerGroups define the set of availability zones we want to distribute pods over.
         serverGroups: []
+        # Pod defines the policy to create pod for the couchbase pod.
         pod:
           volumeMounts:
             default: couchbase
             data:  couchbase
-    securityContext:
-      fsGroup: 1000
+    # VolumeClaimTemplates define the desired characteristics of a volume
+    # that can be requested and claimed by a pod.
     volumeClaimTemplates:
       - metadata:
           name: couchbase
         spec:
-          storageClassName: default
+          storageClassName: standard
           resources:
             requests:
               storage: 2Gi
+
+  # couchbase buckets to create
+  # disable default bucket creation by setting
+  # couchbaseBuckets.default: null
+  #
+  # setting default to null throws warning https://github.com/helm/helm/issues/5184
+  buckets:
+    # A bucket to create by default
+    files:
+      # Name of the bucket
+      name: files
+      # The type of bucket to use
+      type: couchbase
+      # The amount of memory that should be allocated to the bucket
+      memoryQuota: 128Mi
+      # The number of bucket replicates
+      replicas: 1
+      # The priority when compared to other buckets
+      ioPriority: high
+      # The bucket eviction policy which determines behavior during expire and high mem usage
+      evictionPolicy: fullEviction
+      # The bucket's conflict resolution mechanism; which is to be used if a conflict occurs during Cross Data-Center Replication (XDCR). Sequence-based and timestamp-based mechanisms are supported.
+      conflictResolution: seqno
+      # The enable flush option denotes wether the data in the bucket can be flushed
+      enableFlush: true
+      # Enable Index replica specifies whether or not to enable view index replicas for this bucket.
+      enableIndexReplica: false
+      # data compression mode for the bucket to run in [off, passive, active]
+      compressionMode: "passive"
+    users:
+      # Name of the bucket
+      name: users
+      # The type of bucket to use
+      type: couchbase
+      # The amount of memory that should be allocated to the bucket
+      memoryQuota: 128Mi
+      # The number of bucket replicates
+      replicas: 1
+      # The priority when compared to other buckets
+      ioPriority: high
+      # The bucket eviction policy which determines behavior during expire and high mem usage
+      evictionPolicy: fullEviction
+      # The bucket's conflict resolution mechanism; which is to be used if a conflict occurs during Cross Data-Center Replication (XDCR). Sequence-based and timestamp-based mechanisms are supported.
+      conflictResolution: seqno
+      # The enable flush option denotes wether the data in the bucket can be flushed
+      enableFlush: true
+      # Enable Index replica specifies whether or not to enable view index replicas for this bucket.
+      enableIndexReplica: false
+      # data compression mode for the bucket to run in [off, passive, active]
+      compressionMode: "passive"
 
 ########### NSQ ###########
 nsq:
@@ -170,7 +342,7 @@ nsq:
 efs-provisioner:
   enabled: false
   efsProvisioner:
-    efsFileSystemId: "fs-id-here"
+    efsFileSystemId: "<put-fs-id-here>"
     awsRegion: "us-east-1"
     provisionerName: "saferwall.com/aws-efs"
 
@@ -198,7 +370,7 @@ nginx-ingress:
 
 ########### BACKEND ###########
 backend:
-  enabled: false
+  enabled: true
   name: backend
   replicaCount: 1
   containerPort: 8080
@@ -213,7 +385,7 @@ backend:
 
 ########### FRONTEND ###########
 frontend:
-  enabled: false
+  enabled: true
   name: frontend
   replicaCount: 1
   containerPort: 80
@@ -248,14 +420,14 @@ cert-manager:
     defaultIssuerName: letsencrypt-prod
     defaultIssuerKind: ClusterIssuer
 certEmail: admin@saferwall.com
-backendDomainName: dev.api.saferwall.com
-frontendDomainName: dev.saferwall.com
+backendDomainName: api.saferwall.com
+frontendDomainName: saferwall.com
 websiteDomainName: about.saferwall.com
-backendHostname: https://dev.api.saferwall.com
+backendHostname: https://api.saferwall.com
 
 ########### CONSUMER ###########
 consumer:
-  enabled: false
+  enabled: true
   name: consumer
   replicaCount: 1
   image:

--- a/deployments/saferwall/values.yaml
+++ b/deployments/saferwall/values.yaml
@@ -7,6 +7,11 @@
 ##
 global:
   deployEnv: local
+  certEmail: admin@mysaferwall.com
+  backendDomainName: api.mysaferwall.com
+  frontendDomainName: mysaferwall.com
+  websiteDomainName: about.mysaferwall.com
+  backendHostname: http://api.mysaferwall.com
 
 ########### MINIO ###########
 minio:
@@ -419,11 +424,6 @@ cert-manager:
   ingressShim:
     defaultIssuerName: letsencrypt-prod
     defaultIssuerKind: ClusterIssuer
-certEmail: admin@saferwall.com
-backendDomainName: api.saferwall.com
-frontendDomainName: saferwall.com
-websiteDomainName: about.saferwall.com
-backendHostname: https://api.saferwall.com
 
 ########### CONSUMER ###########
 consumer:

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -27,7 +27,7 @@
     ```
     Then run `make minikube-start`.
 6. Building the containers:
-    - Before running any of the builds below, if you are not the _none_ driver, __make sure to eval__ the minikube env variables into your shell using the command: `eval $(minikube docker-env)`.
+    - Before running any of the builds below, if you are not using the _none_ driver, __make sure to eval__ the minikube environment variables into your shell using the command: `eval $(minikube docker-env)`.
     - Build the backend: `make backend-build`
     - Build the frontend: `make ui-build`
     - Build the consumers: `make consumer-build`
@@ -40,22 +40,17 @@
 9. Fetch Helm dependecies: `make helm-update-dependency`.
 10. Edit the `deployments/saferwall/values.yaml`
     - Set `nfs-server-provisioner.enabled` to true.
-11. Install helm chart:
-    - `cd deployments && helm install saferwall --generate-name`.
-12. Wait (~1 min) till the output of `kubectl get pods` show all pods are running fine.
-13. Edit again the `deployments/saferwall/values.yaml`
-    - Set `couchbase-cluster.enabled` to true.
-    - Set `backend.enabled` to true.
-    - Set `frontend.enabled` to true.
-    - Set `consumer.enabled` to true.
-    - If you are  interested to see the logs in EFK:
+    - If you are interested to see the logs in EFK:
         - Set `elasticsearch.enabled` to true.
         - Set `kibana.enabled` to true. 
         - Set `filebeat.enabled` to true.
     - Set `prometheus-operator.enabled` to true if you want to get metrics.
-14. Install the chart:
-    - `cd deployments` if you're not inside the deployments folder.
-    - `helm upgrade saferwall <release-name generated before>`
+11. Install helm chart:
+    - `cd deployments && helm install saferwall --generate-name`.
+12. Wait until the output of `kubectl get pods` show all pods are running fine.
+13. Edit your host file to setup a dns entry for the minikube ip:
+    - `echo "$(minikube ip) mysaferwall.com api.mysaferwall.com" | sudo tee  -a /etc/hosts`
+14. Open the browser and naviguate to `http://mysaferwall.com`
 
 ## Deploying on cloud (AWS)
 


### PR DESCRIPTION
This PR is about:
- bump helm chart dependencies (most importantly couchbase, which does not require anymore the couchbase cluster chart)
- don't deploy ingress as a load balancer in minikube, use addon instead.
