### PR TITLE
[pkg, ui] Display enabled antivirus only

### DIFF
--- a/pkg/consumer/scanners.go
+++ b/pkg/consumer/scanners.go
@@ -276,7 +276,7 @@ func avScan(engine string, filePath string, c chan multiav.ScanResult) {
 	if err != nil {
 		contextLogger.Errorf("Failed to scan file [%s]: %v", engine, err)
 	}
-	c <- multiav.ScanResult{Output: res.Output, Infected: res.Infected, Update: res.Update}
+	c <- multiav.ScanResult{Enabled: enabled, Output: res.Output, Infected: res.Infected, Update: res.Update}
 
 	if err = utils.DeleteFile(filecopyPath); err != nil {
 		contextLogger.Errorf("Failed to delete file path %s.", filecopyPath)

--- a/pkg/grpc/multiav/multiav.go
+++ b/pkg/grpc/multiav/multiav.go
@@ -34,6 +34,7 @@ const (
 
 // ScanResult av result
 type ScanResult struct {
+	Enabled  bool   `json:"enabled"`
 	Output   string `json:"output"`
 	Infected bool   `json:"infected"`
 	Update   int64  `json:"update"`

--- a/ui/src/components/elements/profile/FileCard.vue
+++ b/ui/src/components/elements/profile/FileCard.vue
@@ -19,7 +19,7 @@
         </span>
         <span id="Av">
           <i class="icon fas fa-shield-alt"></i>
-          Antivirus: {{ file.AvDetectionCount }}/12
+          Antivirus: {{ file.AvDetectionCount }}/{{ file.AvCount }}
         </span>
         <span id="timestamp" v-if="time">
           <i class="icon fas fa-clock"></i>

--- a/ui/src/components/elements/profile/Likes.vue
+++ b/ui/src/components/elements/profile/Likes.vue
@@ -25,6 +25,13 @@ export default {
     },
   },
   methods: {
+    getAvCount: function(scans) {
+      var count = 0
+      for (const av of Object.values(scans)) {
+        if (av.enabled) count++
+      }
+      return count
+    },
     getAvDetectionCount: function(scans) {
       var count = 0
       for (const av of Object.values(scans)) {
@@ -37,6 +44,9 @@ export default {
         .get(this.$api_endpoints.FILES + hash + "?fields=sha256,tags,multiav")
         .then((res) => {
           res.data.AvDetectionCount = this.getAvDetectionCount(
+            res.data.multiav.last_scan,
+          )
+          res.data.AvCount = this.getAvCount(
             res.data.multiav.last_scan,
           )
           this.filesData.push(res.data)

--- a/ui/src/components/elements/profile/Submissions.vue
+++ b/ui/src/components/elements/profile/Submissions.vue
@@ -25,6 +25,13 @@ export default {
     },
   },
   methods: {
+    getAvCount: function(scans) {
+      var count = 0
+      for (const av of Object.values(scans)) {
+        if (av.enabled) count++
+      }
+      return count
+    },
     getAvDetectionCount: function(scans) {
       var count = 0
       for (const av of Object.values(scans)) {
@@ -41,6 +48,9 @@ export default {
         )
         .then((res) => {
           res.data.AvDetectionCount = this.getAvDetectionCount(
+            res.data.multiav.last_scan,
+          )
+          res.data.AvCount = this.getAvCount(
             res.data.multiav.last_scan,
           )
           res.data.timestamp = file.timestamp

--- a/ui/src/components/pages/Antivirus.vue
+++ b/ui/src/components/pages/Antivirus.vue
@@ -141,7 +141,15 @@ export default {
       Object.keys(_firstScan).forEach((key) => {
         _firstScan[key].showCopy = false
         _lastScan[key].showCopy = false
+
+        if (!_firstScan[key]['enabled']) {
+          delete _firstScan[key]
+        }
+        if (!_lastScan[key]['enabled']) {
+          delete _lastScan[key]
+        }
       })
+
       return {
         firstScan: _firstScan,
         lastScan: _lastScan,


### PR DESCRIPTION
I noticed the number of AV is hardcoded to 12. Can we make it show only enabled AV? Such as:
![image](https://user-images.githubusercontent.com/4245729/97859123-1bb42980-1d3b-11eb-87ec-cce203f173f1.png)
![image](https://user-images.githubusercontent.com/4245729/97859265-574ef380-1d3b-11eb-9d4a-d6f89b6291b5.png)

This is a breaking change because it require database to have column name `enabled`.