### PR TITLE
feat(pkg/multiav): init av refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -7,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.1.0] - 30/04/2021
+
 ### Added
+
 - ML PE classifier and string ranker.
 - docker-compose and .devcontainer to ease development.
 - A portable executable (PE) file parser.
@@ -18,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `sdk2json`: a package to convert Win32 API definitions to JSON format.
 
 ### Changed
+
 - Consumer docker image is separated to a base image and an app image.
 - Refactor consumer and make it a go module.
 - [Helm] reduce minio MEM request, ES and Kibana CPU request to half a core.
@@ -27,12 +31,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improvement in CI/CD pipeline: include code coverage, test only changed modules & running custom github action runners.
 
 ## [0.0.3] - 2021-15-01
+
 ### Added
+
 - A new antivirus engine (DrWeb).
 - A new antivirus engine (TrendMicro).
 - A Vagrant image (virtualbox) to test locally the product.
 
 ### Changed
+
 - Add config option to choose log level.
 - Add various labels to k8s manifests and enforce resource req and limits.
 - Create seconday indexes for couchbase n1ql queries.
@@ -46,12 +53,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve the CONTRIBUTING doc.
 
 # Fixed:
+
 - Force lower case a sha256 hash before search in Backend thanks to [@hotail](https://github.com/hotail)
-- `AV_LIST` variable in multiav mk was override somewhere thanks to  [@najashark](https://github.com/najashark)
+- `AV_LIST` variable in multiav mk was override somewhere thanks to [@najashark](https://github.com/najashark)
 - Remove `add_kubernetes_metadata` from filebeat config which was causing duplicated data to be sent to kibana and ddosing the kube api server.
 
 ## [0.0.2] - 2020-08-12
+
 ### Added
+
 - Add a cmd tool to batch upload files.
 - Add s3upload pkg to simplify mass-uploading of files into s3.
 - Add upload pkg to simplify uploading a local database of samples to saferwall.
@@ -59,6 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Prometheus Operator helm chart.
 
 ### Changed
+
 - Add nfs-server-provisionner for local testing in minikube.
 - Improve the building process documentation thanks to [Jameel Haffejee](https://github.com/RC114).
 - Reworked to file tags schema.
@@ -69,7 +80,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add ContextLogger in consumer to always log sha256.
 
 ## [0.0.1] - 2020-03-09
+
 ### Added
+
 - Initiale release includes a multi-av scanner + strings + file metadata.
 - UI with options to download, rescan, like a sample and share comments.
 - User profile to track submissions, followers and see activities.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 <p align="center"><a href="https://saferwall.com" target="_blank" rel="noopener noreferrer"><img width="100" src="https://i.imgur.com/zjCOKPo.png" alt="Saferwall logo"></a></p>
-<h4 align="center">Saferwall is an open source malware analysis platform</a>.</h4>
+
+<p align="center">
+<b>Collaborative and Streamlined <ins>Threat Analysis</ins> at Scale</b>
+</p>
 
 <p align="center"> 
   <a href="https://gitter.im/saferwall/community"><img src="https://img.shields.io/gitter/room/saferwall/community?style=flat-square"></a>
@@ -11,16 +14,27 @@
   <img alt="GitHub" src="https://img.shields.io/github/license/saferwall/saferwall?style=flat-square">
   </p>
 
-It aims for the following goals:
+<!-- start elevator-pitch -->
 
-- Be the collaborative platform for _security teams_ and _researchers_ to analyze, identify and share malware samples.
-- Streamline the analysis process to help researchers generates IoC's and analysis reports with **zero friction**.
-- Provide a search index to build intelligence feeds for threat hunting and behavioral signatures.
-- Be _open-source_, _developer friendly_ and _user driven._
+Saferwall allows you to analyze, triage and classify threats in just minutes.
+
+<!-- end elevator-pitch -->
+
+:star: **Collaborative** - Built for _security teams_ and _researchers_ to streamline analysis, identification and sharing malware samples.
+
+:cloud: **Fast & cloud-native** - Scalable and cloud-native by design, deploy in seconds to bare metal or in the cloud.
+
+:zap: **Save time** - Save time on cumbersome analysis tasks, automate and generate IoC's and reports with **zero friction**.
+
+:package: **Batteries included** - All your favorite tools included, build intelligence feeds for hunting threats or generating signatures.
+
+:heart: **Open source first** - We are _open-source_, _developer friendly_ and _user driven._
 
 <p align="center"><img src="https://i.imgur.com/lYv1B4S.png" width="auto" height="auto"></p>
 
-## Features
+---
+
+## Batteries Included
 
 - Static Analysis:
 
@@ -49,7 +63,7 @@ It aims for the following goals:
 
 - Integrations with your own data processing pipeline.
 
-## Installation
+## Get Started
 
 Saferwall takes advantage of [Kubernetes](https://kubernetes.io/) for its high availability, scalability and ecosystem behind it.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
   <img alt="Coverage" src="https://img.shields.io/codecov/c/github/saferwall/saferwall?style=flat-square">
   <img alt="Discord" src="https://img.shields.io/discord/803411418854064148?label=Discord&style=flat-square">
   <img alt="GitHub Workflow Status" src="https://img.shields.io/github/workflow/status/saferwall/saferwall/Test%20Helm%20Charts?style=flat-square">
+  <img alt="Downloads" src="https://img.shields.io/github/downloads/saferwall/saferwall/v0.1.0/total?style=flat-square">
   <img alt="Report Card" src="https://goreportcard.com/badge/github.com/saferwall/saferwall">
   <img alt="GitHub" src="https://img.shields.io/github/license/saferwall/saferwall?style=flat-square">
   </p>

--- a/pkg/gib/gib.go
+++ b/pkg/gib/gib.go
@@ -29,17 +29,17 @@ var (
 	lowerCaseLetters = []string{"a", "b", "c", "d", "e", "f", "g", "h", "i",
 		"j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w",
 		"x", "y", "z"}
-	scoreLenThreshold float64 = 25.
-	scoreLenPenalty   float64 = 0.9233
-	scoreRepPenalty   float64 = 0.9674
+	scoreLenThreshold = 25.
+	scoreLenPenalty   = 0.9233
+	scoreRepPenalty   = 0.9674
 	// MinScore represents the absolute minimal score for any given string
-	MinScore float64 = 8.6
+	MinScore = 8.6
 )
 
 // ngramsFromString returns a list of all n-grams of length n in a given string s.
 func ngramsFromString(s string, n int) []string {
 
-	var ngrams []string = make([]string, 0, len(s))
+	var ngrams = make([]string, 0, len(s))
 
 	for i := 0; i < len(s)-n+1; i++ {
 		ngrams = append(ngrams, s[i:i+n])

--- a/pkg/multiav/multiav.go
+++ b/pkg/multiav/multiav.go
@@ -1,0 +1,5 @@
+package multiav
+
+// AVScanner is an interface for av scanner implementations
+type AVScanner interface {
+}


### PR DESCRIPTION
Adding the following to this PR :

    re-factor multiav package
    send file bytes instead of dropping the file in the NFS share
    move from logrus to Zap in multiAV scanner
    wrap grpc errors in a ScanResult
