### PR TITLE
Upload memdumps and screenshots thumbnails to obj storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.0] - 11/11/2022
+
+## [0.4.0] - Unreleased
 
 ### Added
 
-- Sandbox agent health check + basic sysinfo and env data collection [##395](https://github.com/saferwall/saferwall/pull/395).
+- Upload sandbox memdumps and screenshots thumbnails to obj storage [#398](https://github.com/saferwall/saferwall/pull/398).
+- Upload sandbox desktop screenshots to obj storage [#397](https://github.com/saferwall/saferwall/pull/397).
+- Sandbox agent health check + basic sysinfo and env data collection [#395](https://github.com/saferwall/saferwall/pull/395).
 - Push sandbox payload results to the aggregator [#391](https://github.com/saferwall/saferwall/pull/391).
 - MultiAV McAfee enable scan for potentially unwanted program [#387](https://github.com/saferwall/saferwall/pull/387).
 - Numerous updates to support different types of messages for the aggregator [#383](https://github.com/saferwall/saferwall/pull/383).

--- a/services/sandbox/sandbox.go
+++ b/services/sandbox/sandbox.go
@@ -277,6 +277,10 @@ func (s *Service) HandleMessage(m *gonsq.Message) error {
 
 	// If something went wrong during detonation, we still want to
 	// upload the results back to the backend.
+	detonationKey := sha256 + "/" + detonationID + "/"
+	agentLogKey := detonationKey + "agent_log.json"
+	sandboxLogKey := detonationKey + "sandbox_log.json"
+	apiTraceKey := detonationKey + "api_trace.json"
 	payloads = []*pb.Message_Payload{
 		{Key: detonationID, Path: "api_trace", Body: res.APITrace, Kind: pb.Message_DBUPDATE},
 		{Key: detonationID, Path: "agent_log", Body: res.AgentLog, Kind: pb.Message_DBUPDATE},
@@ -284,11 +288,14 @@ func (s *Service) HandleMessage(m *gonsq.Message) error {
 		{Key: detonationID, Path: "env", Body: toJSON(res.Environment), Kind: pb.Message_DBUPDATE},
 		{Key: detonationID, Path: "scan_cfg", Body: toJSON(res.ScanCfg), Kind: pb.Message_DBUPDATE},
 		{Key: detonationID, Path: "screenshots", Body: toJSON(res.Screenshots), Kind: pb.Message_DBUPDATE},
+		{Key: agentLogKey, Body: res.AgentLog, Kind: pb.Message_UPLOAD},
+		{Key: sandboxLogKey, Body: res.SandboxLog, Kind: pb.Message_UPLOAD},
+		{Key: apiTraceKey, Body: res.APITrace, Kind: pb.Message_UPLOAD},
 	}
 
 	// Screenshots are uploaded to file system storage like s3.
 	for _, sc := range res.Screenshots {
-		objKey := sha256 + "/" + detonationID + "/" + "screenshots" + "/" + sc.Name
+		objKey := detonationKey + "screenshots" + "/" + sc.Name
 		payload := pb.Message_Payload{
 			Key:  objKey,
 			Body: sc.Content,
@@ -300,7 +307,7 @@ func (s *Service) HandleMessage(m *gonsq.Message) error {
 	// Artifacts like memory dumps and dropped files are also uploaded to
 	// file system storage like s3.
 	for _, artifact := range res.Artifacts {
-		objKey := sha256 + "/" + detonationID + "/" + "artifacts" + "/" + artifact.Name
+		objKey := detonationKey + "artifacts" + "/" + artifact.Name
 		payload := pb.Message_Payload{
 			Key:  objKey,
 			Body: artifact.Content,

--- a/services/sandbox/vm.go
+++ b/services/sandbox/vm.go
@@ -87,8 +87,8 @@ func (vm *VM) ping() error {
 	return nil
 }
 
-// freeVM makes the VM free for consumption.
-func (vm *VM) freeVM() {
+// free makes the VM free for consumption.
+func (vm *VM) free() {
 	vm.InUse = false
 }
 


### PR DESCRIPTION
- Feat (sandbox): Upload memdumps and sreenshots thumbnails to remote storage.
- Feat(sandbox): Set the active detonation guid and append det ID in file object.