### PR TITLE
chore: helm chart dependency updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ externals/
 
 # Helm
 **/charts/*.tgz
+
+hack/

--- a/build/k8s/kind-cluster-config.yaml
+++ b/build/k8s/kind-cluster-config.yaml
@@ -1,8 +1,9 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+name: sfw-dev-cluster
 nodes:
 - role: control-plane
-  image: kindest/node:v1.23.12@sha256:9402cf1330bbd3a0d097d2033fa489b2abe40d479cc5ef47d0b6a6960613148a
+  image: kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
   kubeadmConfigPatches:
   - |
     kind: InitConfiguration
@@ -16,3 +17,9 @@ nodes:
   - containerPort: 443
     hostPort: 443
     protocol: TCP
+- role: worker
+  image: kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
+- role: worker
+  image: kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
+- role: worker
+  image: kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72

--- a/build/k8s/loki-values.yaml
+++ b/build/k8s/loki-values.yaml
@@ -1,0 +1,20 @@
+global:
+  clusterDomain: "saferwall.local"
+  dnsService: "coredns"
+loki:
+  commonConfig:
+    replication_factor: 3
+  auth_enabled: false
+storage:
+  type: 'filesystem'
+test:
+  enabled: false
+monitoring:
+  selfMonitoring:
+    enabled: false
+    grafanaAgent:
+      installOperator: false
+    lokiCanary:
+      enabled: false
+minio:
+  enabled: true

--- a/build/mk/exiftool.mk
+++ b/build/mk/exiftool.mk
@@ -1,4 +1,4 @@
-EXIF_VER = 12.69
+EXIF_VER = 12.76
 exiftool-install: # Install ExifTool
 	wget https://exiftool.org/Image-ExifTool-$(EXIF_VER).tar.gz
 	gzip -dc Image-ExifTool-$(EXIF_VER).tar.gz | tar -xf -

--- a/build/mk/helm.mk
+++ b/build/mk/helm.mk
@@ -1,4 +1,4 @@
-HELM_VERSION = 3.10.2
+HELM_VERSION = 3.14.0
 HELM_ZIP = helm-v$(HELM_VERSION)-linux-amd64.tar.gz
 HELM_URL = https://get.helm.sh/$(HELM_ZIP)
 
@@ -24,6 +24,7 @@ helm-add-repos:	## Add the required Helm Charts repositories.
 	helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 	helm repo add grafana https://grafana.github.io/helm-charts
 	helm repo add nsqio https://nsqio.github.io/helm-chart
+	helm repo add nfs-ganesha-server-and-external-provisioner https://kubernetes-sigs.github.io/nfs-ganesha-server-and-external-provisioner/
 
 	# Update your local Helm chart repository cache.
 	helm repo update

--- a/build/mk/k8s.mk
+++ b/build/mk/k8s.mk
@@ -117,9 +117,12 @@ COUCHBASE_OPERATOR=2.60.0
 k8s-install-couchbase-crds: ## Install couchbase operator CRDs.
 	kubectl apply -f https://raw.githubusercontent.com/couchbase-partners/helm-charts/couchbase-operator-$(COUCHBASE_OPERATOR)/charts/couchbase-operator/crds/couchbase.crds.yaml
 
-k8s-cert-manager-rm-crd: ## Delete cert-manager crd objects.
+k8s-rm-cert-manager-crds: ## Delete cert-manager crd objects.
 	kubectl get crd | grep cert-manager | xargs --no-run-if-empty kubectl delete crd
 	kubectl delete namespace cert-manager
+
+k8s-rm-couchbase-crds: ## Delete couchbase crd objects.
+	kubectl get crd | grep couchbase | xargs --no-run-if-empty kubectl delete crd
 
 k8s-events: ## Get Kubernetes cluster events.
 	kubectl get events --sort-by='.metadata.creationTimestamp'

--- a/build/mk/k8s.mk
+++ b/build/mk/k8s.mk
@@ -110,11 +110,19 @@ k8s-install-kube-prometheus-stack: ## Install Kube Prometheus Stack.
 		--create-namespace \
 		--namespace prometheus
 
-LOKI_STACK=2.10.1
-k8s-install-loki-stack: ## Install Loki Stack
-	helm install loki grafana/loki-stack \
-		--version v$(LOKI_STACK) \
-		--namespace prometheus
+LOKI= 5.42.1
+k8s-install-loki: ## Install Loki.
+	helm install loki grafana/loki \
+		--version v$(LOKI) \
+		-f $(ROOT_DIR)/build/k8s/loki-values.yaml \
+		--namespace monitoring \
+		--create-namespace
+
+PROMTAIL= 6.15.5
+k8s-install-promtail: ## Install Loki Distributed.
+	helm install promtail grafana/promtail \
+		--version v$(PROMTAIL) \
+		--namespace monitoring
 
 COUCHBASE_OPERATOR=2.60.0
 k8s-install-couchbase-crds: ## Install couchbase operator CRDs.
@@ -132,6 +140,10 @@ k8s-events: ## Get Kubernetes cluster events.
 
 k8s-delete-terminating-pods: ## Force delete pods stuck at `Terminating` status
 	for p in $$(kubectl get pods | grep Terminating | awk '{print $$1}'); \
+	 do kubectl delete pod $$p --grace-period=0 --force;done
+
+k8s-delete-erroring-pods: ## Force delete pods stuck at `Error` status
+	for p in $$(kubectl get pods | grep Error | awk '{print $$1}'); \
 	 do kubectl delete pod $$p --grace-period=0 --force;done
 
 k8s-delete-evicted-pods: ## Clean up all evicted pods

--- a/build/mk/k8s.mk
+++ b/build/mk/k8s.mk
@@ -113,8 +113,9 @@ k8s-install-loki-stack: ## Install Loki Stack
 		--version v$(LOKI_STACK) \
 		--namespace loki-stack
 
+COUCHBASE_OPERATOR=2.60.0
 k8s-install-couchbase-crds: ## Install couchbase operator CRDs.
-	kubectl apply -f https://raw.githubusercontent.com/couchbase-partners/helm-charts/master/charts/couchbase-operator/crds/couchbase.crds.yaml
+	kubectl apply -f https://raw.githubusercontent.com/couchbase-partners/helm-charts/couchbase-operator-$(COUCHBASE_OPERATOR)/charts/couchbase-operator/crds/couchbase.crds.yaml
 
 k8s-cert-manager-rm-crd: ## Delete cert-manager crd objects.
 	kubectl get crd | grep cert-manager | xargs --no-run-if-empty kubectl delete crd

--- a/build/mk/k8s.mk
+++ b/build/mk/k8s.mk
@@ -1,4 +1,4 @@
-KUBECTL_VER = 1.23.6
+KUBECTL_VER = 1.28.6
 kubectl-install: ## Install kubectl.
 	@kubectl version --client | grep $(KUBECTL_VER); \
 		if [ $$? -eq 1 ]; then \
@@ -10,18 +10,18 @@ kubectl-install: ## Install kubectl.
 			echo "${GREEN} [*] Kubectl already installed ${RESET}"; \
 		fi
 
-KUBECTX_VER = 0.9.4
+KUBECTX_VER = 0.9.5
 KUBECTX_URL= https://github.com/ahmetb/kubectx/releases/download/v$(KUBECTX_VER)/kubectx_v$(KUBECTX_VER)_linux_x86_64.tar.gz
-k8s-kubectx-install: ## Install kubectx
+kubectx-install: ## Install kubectx
 	wget -N $(KUBECTX_URL) -O /tmp/kubectx.tar.gz
 	tar zxvf /tmp/kubectx.tar.gz -C /tmp
 	sudo mv /tmp/kubectx /usr/local/bin/
 	chmod +x /usr/local/bin/kubectx
 	kubectx
 
-KUBENS_VER = 0.9.4
+KUBENS_VER = 0.9.5
 KUBENS_URL = https://github.com/ahmetb/kubectx/releases/download/v$(KUBENS_VER)/kubens_v$(KUBENS_VER)_linux_x86_64.tar.gz
-k8s-kubens-install: ## Install Kubens
+kubens-install: ## Install Kubens
 	wget -N $(KUBENS_URL) -O /tmp/kubens.tar.gz
 	tar zxvf /tmp/kubens.tar.gz -C /tmp
 	sudo mv /tmp/kubens /usr/local/bin/
@@ -49,6 +49,10 @@ k8s-pf-grafana: ## Port fordward grafana dashboard service.
 
 k8s-pf-couchbase: ## Port fordward couchbase ui service.
 	kubectl port-forward svc/couchbase-cluster-ui 8091:8091 --address='0.0.0.0' &
+	while true ; do nc -vz 127.0.0.1 8091 ; sleep 5 ; done
+
+k8s-pf-hubble: ## Port fordward hubble ui service.
+	kubectl port-forward -n kube-system svc/hubble-ui 12000:80 --address='0.0.0.0' &
 	while true ; do nc -vz 127.0.0.1 8091 ; sleep 5 ; done
 
 k8s-pf: ## Port forward all services.
@@ -106,12 +110,11 @@ k8s-install-kube-prometheus-stack: ## Install Kube Prometheus Stack.
 		--create-namespace \
 		--namespace prometheus
 
-LOKI_STACK=2.9.10
+LOKI_STACK=2.10.1
 k8s-install-loki-stack: ## Install Loki Stack
-	kubectl create namespace loki-stack
-	helm install loki-stack grafana/loki-stack \
+	helm install loki grafana/loki-stack \
 		--version v$(LOKI_STACK) \
-		--namespace loki-stack
+		--namespace prometheus
 
 COUCHBASE_OPERATOR=2.60.0
 k8s-install-couchbase-crds: ## Install couchbase operator CRDs.

--- a/build/mk/kind.mk
+++ b/build/mk/kind.mk
@@ -1,15 +1,15 @@
-KIND_VERSION = 0.17.0
+KIND_VERSION = 0.20.0
 kind-install: ## Install Kind for local kubernetes cluster deployements.
 	curl -o kind -sS -L https://kind.sigs.k8s.io/dl/v$(KIND_VERSION)/kind-linux-amd64
 	chmod +x kind
 	sudo mv kind /usr/local/bin
 	kind version
 
-KIND_CLUSTER_NAME = sfw
+KIND_CLUSTER_NAME = sfw-dev
 kind-create-cluster:	## Create Kind cluster.
 	kind get clusters
 	kind create cluster --name $(KIND_CLUSTER_NAME) --config build/k8s/kind-cluster-config.yaml
-	kubectl cluster-info --context kind-sfw
+	kubectl cluster-info --context kind-$(KIND_CLUSTER_NAME)
 
 kind-deploy-ingress-nginx: ## Deploy ingress-nginx in Kind.
 	# The manifests contains kind specific patches to forward the hostPorts to the ingress controller,

--- a/build/mk/yara.mk
+++ b/build/mk/yara.mk
@@ -9,7 +9,7 @@ yara-install:	# Install yara
 	tar zxvf v${YARA_ARCHIVE}
 	cd ./yara-${YARA_VERSION} \
 		&& ./bootstrap.sh \
-		&& ./configure --enable-magic \
+		&& ./configure \
 		&& make -j $(shell nproc)\
 		&& sudo make install \
 		&& sudo ldconfig

--- a/deployments/saferwall/Chart.lock
+++ b/deployments/saferwall/Chart.lock
@@ -1,21 +1,21 @@
 dependencies:
 - name: minio
   repository: https://charts.min.io/
-  version: 5.0.1
+  version: 5.0.15
 - name: couchbase-operator
   repository: https://couchbase-partners.github.io/helm-charts/
-  version: 2.32.2
+  version: 2.60.0
 - name: aws-efs-csi-driver
   repository: https://kubernetes-sigs.github.io/aws-efs-csi-driver/
-  version: 2.2.6
+  version: 2.5.4
 - name: nfs-server-provisioner
   repository: https://kubernetes-sigs.github.io/nfs-ganesha-server-and-external-provisioner/
   version: 1.8.0
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx/
-  version: 4.4.2
+  version: 4.9.1
 - name: nsq
   repository: https://nsqio.github.io/helm-chart/
-  version: 0.0.8
-digest: sha256:8261a732710340004da6bfa211e34b6e2973498fd45e2817051630a77e407100
-generated: "2023-04-17T14:28:31.338260594+10:00"
+  version: 0.0.10
+digest: sha256:930050746c6f980f0f2fb287ae9120e5b2ab4a31c13da8149f3440234c405d7e
+generated: "2024-02-01T14:58:27.461188581+11:00"

--- a/deployments/saferwall/Chart.yaml
+++ b/deployments/saferwall/Chart.yaml
@@ -14,14 +14,14 @@ maintainers:
 dependencies:
     - name: minio
       repository: https://charts.min.io/
-      version: 5.0.1
+      version: 5.0.15
       condition: minio.enabled
     - name: couchbase-operator
-      version: 2.32.2
+      version: 2.60.0
       repository: https://couchbase-partners.github.io/helm-charts/
       condition: couchbase-operator.enabled
     - name: aws-efs-csi-driver
-      version: 2.2.6
+      version: 2.5.4
       repository: https://kubernetes-sigs.github.io/aws-efs-csi-driver/
       condition: aws-efs-csi-driver.enabled
     - name: nfs-server-provisioner
@@ -29,10 +29,10 @@ dependencies:
       repository: https://kubernetes-sigs.github.io/nfs-ganesha-server-and-external-provisioner/
       condition: nfs-server-provisioner.enabled
     - name: ingress-nginx
-      version: 4.4.2
+      version: 4.9.1
       repository: https://kubernetes.github.io/ingress-nginx/
       condition: ingress-nginx.enabled
     - name: nsq
-      version: 0.0.8
+      version: 0.0.10
       repository: https://nsqio.github.io/helm-chart/
       condition: nsq.enabled

--- a/deployments/saferwall/Chart.yaml
+++ b/deployments/saferwall/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: saferwall
 description: A hackable malware sandbox for the 21st Century
 type: application
-version: 0.4.0
-appVersion: 0.4.0
+version: 0.5.0
+appVersion: 0.5.0
 home: https://saferwall.com
 icon: https://saferwall.com/favicon.png
 sources:

--- a/deployments/saferwall/templates/aggregator-deployment.yaml
+++ b/deployments/saferwall/templates/aggregator-deployment.yaml
@@ -49,13 +49,13 @@ spec:
               path: prod.toml
       initContainers:
       - name: wait-for-couchbase
-        image: groundnuty/k8s-wait-for:v1.5.1
+        image: groundnuty/k8s-wait-for:v2.0
         imagePullPolicy: Always
         args:
         - "pod"
         - "-lapp=couchbase"
       - name: wait-for-nsqlookupd
-        image: groundnuty/k8s-wait-for:v1.5.1
+        image: groundnuty/k8s-wait-for:v2.0
         imagePullPolicy: Always
         args:
         - 'pod'

--- a/deployments/saferwall/templates/ingress.yaml
+++ b/deployments/saferwall/templates/ingress.yaml
@@ -12,10 +12,13 @@ metadata:
 spec:
   tls:
   - hosts:
+{{- if .Values.ui.enabled }}
     - {{ include "saferwall.ui-hostname" . }}
+{{- end }}
     - {{ include "saferwall.webapis-hostname" . }}
     secretName: {{ include "saferwall.fullname" . }}-tls
   rules:
+{{- if .Values.ui.enabled }}
   - host: {{ include "saferwall.ui-hostname" . }}
     http:
       paths:
@@ -26,6 +29,7 @@ spec:
             name: {{ include "saferwall.fullname" . }}-ui
             port:
               number: {{ .Values.ui.service.port }}
+{{- end }}
   - host: {{ include "saferwall.webapis-hostname" . }}
     http:
       paths:

--- a/deployments/saferwall/templates/k8s-wait-for-rbac.yaml
+++ b/deployments/saferwall/templates/k8s-wait-for-rbac.yaml
@@ -22,4 +22,3 @@ roleRef:
   kind: ClusterRole
   name: {{ .Release.Name }}-k8s-wait-for
   apiGroup: rbac.authorization.k8s.io
-

--- a/deployments/saferwall/templates/meta-deployment.yaml
+++ b/deployments/saferwall/templates/meta-deployment.yaml
@@ -47,13 +47,13 @@ spec:
               path: prod.toml
       initContainers:
       - name: wait-for-nsqd
-        image: groundnuty/k8s-wait-for:v1.4
+        image: groundnuty/k8s-wait-for:v2.0
         imagePullPolicy: Always
         args:
           - "pod"
           - '-lapp.kubernetes.io/component=nsqd'
       - name: wait-for-nsqlookupd
-        image: groundnuty/k8s-wait-for:v1.4
+        image: groundnuty/k8s-wait-for:v2.0
         imagePullPolicy: Always
         args:
           - "pod"

--- a/deployments/saferwall/templates/orchestrator-deployment.yaml
+++ b/deployments/saferwall/templates/orchestrator-deployment.yaml
@@ -49,13 +49,13 @@ spec:
               path: prod.toml
       initContainers:
       - name: wait-for-nsqd
-        image: groundnuty/k8s-wait-for:v1.5.1
+        image: groundnuty/k8s-wait-for:v2.0
         imagePullPolicy: Always
         args:
           - "pod"
           - '-lapp.kubernetes.io/component=nsqd'
       - name: wait-for-nsqlookupd
-        image: groundnuty/k8s-wait-for:v1.5.1
+        image: groundnuty/k8s-wait-for:v2.0
         imagePullPolicy: Always
         args:
           - "pod"

--- a/deployments/saferwall/templates/pe-deployment.yaml
+++ b/deployments/saferwall/templates/pe-deployment.yaml
@@ -49,13 +49,13 @@ spec:
               path: prod.toml
       initContainers:
       - name: wait-for-nsqd
-        image: groundnuty/k8s-wait-for:v1.5.1
+        image: groundnuty/k8s-wait-for:v2.0
         imagePullPolicy: Always
         args:
           - "pod"
           - '-lapp.kubernetes.io/component=nsqd'
       - name: wait-for-nsqlookupd
-        image: groundnuty/k8s-wait-for:v1.5.1
+        image: groundnuty/k8s-wait-for:v2.0
         imagePullPolicy: Always
         args:
           - "pod"

--- a/deployments/saferwall/templates/postprocessor-deployment.yaml
+++ b/deployments/saferwall/templates/postprocessor-deployment.yaml
@@ -47,13 +47,13 @@ spec:
               path: prod.toml
       initContainers:
       - name: wait-for-nsqd
-        image: groundnuty/k8s-wait-for:v1.5.1
+        image: groundnuty/k8s-wait-for:v2.0
         imagePullPolicy: Always
         args:
           - "pod"
           - '-lapp.kubernetes.io/component=nsqd'
       - name: wait-for-nsqlookupd
-        image: groundnuty/k8s-wait-for:v1.5.1
+        image: groundnuty/k8s-wait-for:v2.0
         imagePullPolicy: Always
         args:
           - "pod"

--- a/deployments/saferwall/templates/sandbox-daemonset.yaml
+++ b/deployments/saferwall/templates/sandbox-daemonset.yaml
@@ -49,13 +49,13 @@ spec:
               path: prod.toml
       initContainers:
       - name: wait-for-nsqd
-        image: groundnuty/k8s-wait-for:v1.5.1
+        image: groundnuty/k8s-wait-for:v2.0
         imagePullPolicy: Always
         args:
           - "pod"
           - '-lapp.kubernetes.io/component=nsqd'
       - name: wait-for-nsqlookupd
-        image: groundnuty/k8s-wait-for:v1.5.1
+        image: groundnuty/k8s-wait-for:v2.0
         imagePullPolicy: Always
         args:
           - "pod"

--- a/deployments/saferwall/templates/webapis-deployments.yaml
+++ b/deployments/saferwall/templates/webapis-deployments.yaml
@@ -44,7 +44,7 @@ spec:
               path: prod.toml
       initContainers:
         - name: wait-for-couchbase
-          image: groundnuty/k8s-wait-for:v1.5.1
+          image: groundnuty/k8s-wait-for:v2.0
           imagePullPolicy: Always
           args:
             - "pod"


### PR DESCRIPTION
- bump helm and add nfs-ganesha-server-and-external-provisioner helm repo
- bump addons: metallb, kube-prometheus-stack, cert-manager + wait for metallb before L3 advertisement
- download couchbase operator crd for a matching version
- bump main helm chart dependencies
- mk command to remove cb crds
- bump wait-for sidecar container
- bump helm chart version
- create ingress entry only when UI is enabled
- bump kind cluster version
- bump kubens, kubectx
- install loki and promtail separately as loki-stack is not updated

    


    


    