### PR TITLE
feat(ql): Move saferwall ql implementation to monorepo

### DIFF
--- a/internal/ql/README.md
+++ b/internal/ql/README.md
@@ -1,0 +1,71 @@
+# Saferwall Query Language
+
+`ql` package implements a parsing and transpiling of _search terms or modifiers_ into Couchbase SQL++.
+
+## API and Workflow
+
+The package API is rather simple.
+
+```go
+
+package main
+
+import ql "github.com/saferwall/internal/ql"
+
+func main() {
+
+    exampleQuery := "type:pe, size:1mb+, ls:2021-03-01T00:00:00"
+    n1ql := ql.NewParser().Parse(exampleQuery).Compile()
+    fmt.Println(n1ql)
+}
+
+```
+
+```sh
+
+$ go run example.go
+
+SELECT * from bucket where filetype == "pe" AND filesize > 300 AND lastSubmission = 2021-03-01T00:00:00
+
+```
+
+## Query Language Reference
+
+### File Information
+
+The following keywords are valid search terms for all file types.
+
+* ```size```
+* ```type```
+* ```fs```
+* ```ls```
+* ```positives```
+* ```name```
+* ```tag```
+* ```meta```
+
+### Filetype Specific Keywords
+
+The following keywords are valid search terms for binary files only.
+
+* ```section```
+* ```imports```
+* ```exports```
+
+### Operators
+
+You can apply operators on different modifiers to build precise search terms.
+
+* ```and``` : boolean AND operation, both modifiers must be satisified.
+* ```or```  : boolean OR operation, only a single modifier needs to be satisfied.
+
+## Supported Modifiers
+
+| Modifier  | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| size      | Filters the files to be returned according to size. The size can be specified in bytes (default), kilobytes or megabytes. Trailing plus or minus sign will retrieve those files with a size, respectively, larger than or smaller than the one provided.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| type      | Filters the type of file to be returned (i.e. magic signature). Example: type:elf. This is the full list of available file type literals: Executables: peexe, pedll, neexe, nedll, mz, msi, com, coff, elf, krnl, rpm, linux, macho. Internet: html, xml, flash, fla, iecookie, bittorrent, email, outlook, cap. Phones&tablets: symbian, palmos, wince, android, iphone. Images: jpeg, emf, tiff, gif, png, bmp, gimp, indesign, psd, targa, xws, dib, jng, ico, fpx, eps, svg. Video&audio: ogg, flc, fli, mp3, flac, wav, midi, avi, mpeg, qt, asf, divx, flv, wma, wmv, rm, mov, mp4, 3gp. Documents: text, pdf, ps, doc, docx, rtf, ppt, pptx, xls, xlsx, odp, ods, odt, hwp, gul, ebook, latex. Bundles: isoimage, zip, gzip, bzip, rzip, dzip, 7zip, cab, jar, rar, mscompress, ace, arc, arj, asd, blackhole, kgb. Code: script, php, python, perl, ruby, c, cpp, java, shell, pascal, awk, dyalog, fortran, java-bytecode. Apple: apple, mac, applesingle, appledouble, machfs, appleplist, maclib. Miscellaneous: lnk, ttf, rom. |
+| fs        | Filters the files to be returned according to the first submission date.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| ls        | Filters the files to be returned according to the last submission date.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| positives | Filters the files to be returned according to the number of antivirus vendors that detected it upon scanning with VirusTotal. It allows you to specify larger than or smaller than values.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| name      | Returns the files submitted to VirusTotal with a file name that contains the literal provided.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |

--- a/internal/ql/ast.go
+++ b/internal/ql/ast.go
@@ -1,0 +1,50 @@
+package ql
+
+import (
+	"strings"
+)
+
+// Node represents an AST node
+type Node interface {
+	Literal() string
+}
+
+// QueryStatement represents a query statement in the form (IDENTIFER:VALUE).
+type QueryStatement interface {
+	Node
+	statementNode()
+}
+
+// SearchQuery represents a list of query statements.
+type SearchQuery struct {
+	Statements []QueryStatement
+}
+
+// Literal implements the Node interface for search query.
+func (s SearchQuery) Literal() string {
+	if len(s.Statements) > 0 {
+		return s.Statements[0].Literal()
+	}
+	return ""
+}
+
+// SingleQuery represent queries of the form identifier:value
+// such as type:elf or size:+100kb these operates with a single rhs value.
+// Such queries are parsed as {SIZE,=/>/<,100} or {TYPE,=,ELF}
+type SingleQuery struct {
+	Token
+	Op    string
+	Value string
+}
+
+// statmentNode to implement the QueryStatement interface.
+func (sq SingleQuery) statementNode() {}
+
+// Literal to implement the QueryStatement interface.
+func (sq SingleQuery) Literal() string {
+	var sb strings.Builder
+	sb.WriteString(string(sq.Token.Literal))
+	sb.WriteString(sq.Op)
+	sb.WriteString(sq.Value)
+	return sb.String()
+}

--- a/internal/ql/charet.go
+++ b/internal/ql/charet.go
@@ -1,0 +1,23 @@
+package ql
+
+// chart.go implements several character classes and helper functions.
+
+// isWhitespace checks if a given char is a whitespace
+func isWhitespace(ch byte) bool {
+	return ch == ' ' || ch == '\n' || ch == '\t' || ch == '\r'
+}
+
+// isLetter checks if a given char is a letter in the range [aA-zZ]
+func isLetter(ch byte) bool {
+	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')
+}
+
+// isDigit checks if a given byte is a digit.
+func isDigit(ch byte) bool {
+	return '0' <= ch && ch <= '9'
+}
+
+// isOperator checks if a given character is an operator
+func isOperator(ch byte) bool {
+	return (ch == '+' || ch == '-')
+}

--- a/internal/ql/charet_test.go
+++ b/internal/ql/charet_test.go
@@ -1,0 +1,116 @@
+package ql
+
+import "testing"
+
+func TestCharet(t *testing.T) {
+	t.Run("TestIsWhitespace", func(t *testing.T) {
+		testCases := []struct {
+			v        byte
+			expected bool
+		}{
+			{
+				' ',
+				true,
+			}, {
+				' ',
+				true,
+			}, {
+				'a',
+				false,
+			},
+		}
+
+		for _, tt := range testCases {
+			if isWhitespace(tt.v) != tt.expected {
+				t.Error("failed to identify whitespace")
+			}
+		}
+	})
+	t.Run("TestIsLetter", func(t *testing.T) {
+		testCases := []struct {
+			v        byte
+			expected bool
+		}{
+			{
+				'a',
+				true,
+			}, {
+				'b',
+				true,
+			}, {
+				',',
+				false,
+			}, {
+				':',
+				false,
+			}, {
+				'3',
+				false,
+			},
+		}
+		for _, tt := range testCases {
+			if isLetter(tt.v) != tt.expected {
+				t.Error("failed to identify letters")
+			}
+		}
+	})
+	t.Run("TestIsDigit", func(t *testing.T) {
+		testCases := []struct {
+			v        byte
+			expected bool
+		}{
+			{
+				'a',
+				false,
+			}, {
+				'8',
+				true,
+			}, {
+				',',
+				false,
+			}, {
+				':',
+				false,
+			}, {
+				'3',
+				true,
+			},
+		}
+		for _, tt := range testCases {
+			if isDigit(tt.v) != tt.expected {
+				t.Error("failed to identify letters")
+			}
+		}
+	})
+	t.Run("TestIsOperator", func(t *testing.T) {
+		testCases := []struct {
+			v        byte
+			expected bool
+		}{
+			{
+				'+',
+				true,
+			}, {
+				'-',
+				true,
+			}, {
+				',',
+				false,
+			}, {
+				':',
+				false,
+			}, {
+				'3',
+				false,
+			}, {
+				'a',
+				false,
+			},
+		}
+		for _, tt := range testCases {
+			if isOperator(tt.v) != tt.expected {
+				t.Error("failed to identify operators")
+			}
+		}
+	})
+}

--- a/internal/ql/conv.go
+++ b/internal/ql/conv.go
@@ -1,0 +1,38 @@
+package ql
+
+import "strconv"
+
+// mbToBytes converts a MB value to its bytes value.
+func mbToBytes(v int) int {
+	return v * 1e6
+}
+
+// kbToBytes converts a KB value to its bytes value.
+func kbToBytes(v int) int {
+	return v * 1e3
+}
+
+// mbToBytesStr converts a MB value to its bytes value for strings.
+func mbToBytesStr(v string) string {
+	n, _ := strconv.Atoi(v)
+	return strconv.Itoa(mbToBytes(n))
+}
+
+// kbToBytesStr converts a MB value to its bytes value for strings.
+func kbToBytesStr(v string) string {
+	n, _ := strconv.Atoi(v)
+	return strconv.Itoa(kbToBytes(n))
+}
+
+// convOp converts operator from +/-/= to >= <= or =.
+func convOp(op string) string {
+	switch op {
+	case "+":
+		return ">="
+	case "-":
+		return "<="
+	case "=":
+		return "="
+	}
+	return "="
+}

--- a/internal/ql/conv_test.go
+++ b/internal/ql/conv_test.go
@@ -1,0 +1,97 @@
+package ql
+
+import "testing"
+
+func TestConv(t *testing.T) {
+	t.Run("TestMBSizeConversion", func(t *testing.T) {
+		testCases := []struct {
+			v        int
+			expected int
+		}{
+			{
+				5,
+				5000000,
+			},
+		}
+
+		for _, tt := range testCases {
+			if mbToBytes(tt.v) != tt.expected {
+				t.Errorf("conversion failed expected %d got %d : ", tt.expected, mbToBytes(tt.v))
+			}
+		}
+	})
+	t.Run("TestKBSizeConversion", func(t *testing.T) {
+		testCases := []struct {
+			v        int
+			expected int
+		}{
+			{
+				200,
+				200000,
+			},
+		}
+
+		for _, tt := range testCases {
+			if kbToBytes(tt.v) != tt.expected {
+				t.Errorf("conversion failed expected %d got %d : ", tt.expected, kbToBytes(tt.v))
+			}
+		}
+	})
+	t.Run("TestMBSizeConversionString", func(t *testing.T) {
+		testCases := []struct {
+			v        string
+			expected string
+		}{
+			{
+				"5",
+				"5000000",
+			},
+		}
+
+		for _, tt := range testCases {
+			if mbToBytesStr(tt.v) != tt.expected {
+				t.Errorf("conversion failed expected %s got %s : ", tt.expected, mbToBytesStr(tt.v))
+			}
+		}
+	})
+	t.Run("TestKBSizeConversionStrings", func(t *testing.T) {
+		testCases := []struct {
+			v        string
+			expected string
+		}{
+			{
+				"200",
+				"200000",
+			},
+		}
+
+		for _, tt := range testCases {
+			if kbToBytesStr(tt.v) != tt.expected {
+				t.Errorf("conversion failed expected %s got %s : ", tt.expected, kbToBytesStr(tt.v))
+			}
+		}
+	})
+	t.Run("TestOpConversionStrings", func(t *testing.T) {
+		testCases := []struct {
+			v        string
+			expected string
+		}{
+			{
+				"+",
+				">=",
+			}, {
+				"-",
+				"<=",
+			}, {
+				"",
+				"=",
+			},
+		}
+
+		for _, tt := range testCases {
+			if convOp(tt.v) != tt.expected {
+				t.Errorf("conversion failed expected %s got %s : ", tt.expected, kbToBytesStr(tt.v))
+			}
+		}
+	})
+}

--- a/internal/ql/datetime.go
+++ b/internal/ql/datetime.go
@@ -1,0 +1,13 @@
+package ql
+
+import "time"
+
+const (
+	defaultLayout = "2006-01-02T15:04:05"
+)
+
+// strToDatetime will convert an RFC3339 datetime to the time.Time go type
+// RFC3339 datetime follows the form : "2012-08-21T16:59:22"
+func strToDatetime(date string) (time.Time, error) {
+	return time.Parse(defaultLayout, date)
+}

--- a/internal/ql/datetime_test.go
+++ b/internal/ql/datetime_test.go
@@ -26,9 +26,7 @@ func TestDatetime(t *testing.T) {
 			}
 			if date.String() != tt.expectedUTC {
 				t.Fatalf("test[%d] expected date=%s got=%s", i, tt.expectedUTC, date.UTC())
-
 			}
 		}
-
 	})
 }

--- a/internal/ql/datetime_test.go
+++ b/internal/ql/datetime_test.go
@@ -1,0 +1,34 @@
+package ql
+
+import "testing"
+
+func TestDatetime(t *testing.T) {
+	t.Run("TestParseCompleteDatetime", func(t *testing.T) {
+		tests := []struct {
+			input        string
+			expectedUTC  string
+			expectedUnix int64
+		}{
+			{
+				input:        "2012-08-21T16:59:22",
+				expectedUTC:  "2012-08-21 16:59:22 +0000 UTC",
+				expectedUnix: 1345568362,
+			},
+		}
+		for i, tt := range tests {
+			date, err := strToDatetime(tt.input)
+			if err != nil {
+				t.Fatalf("test[%d] failed with error %v", i, err)
+			}
+			if date.Unix() != tt.expectedUnix {
+				t.Fatalf("test[%d] expected date=%d got=%d", i, tt.expectedUnix, date.Unix())
+
+			}
+			if date.String() != tt.expectedUTC {
+				t.Fatalf("test[%d] expected date=%s got=%s", i, tt.expectedUTC, date.UTC())
+
+			}
+		}
+
+	})
+}

--- a/internal/ql/error.go
+++ b/internal/ql/error.go
@@ -1,0 +1,13 @@
+package ql
+
+import (
+	"fmt"
+)
+
+// newSyntaxError creates a readable error string for syntax errors.
+func newSyntaxError(ctx string, expected string, got string) error {
+	err := fmt.Errorf(
+		"[%s]syntax error : expected %s got %s", ctx, expected, got,
+	)
+	return err
+}

--- a/internal/ql/fuzz.go
+++ b/internal/ql/fuzz.go
@@ -1,0 +1,17 @@
+// +build gofuzz
+
+package ql
+
+// Fuzz function to be used by https://github.com/dvyukov/go-fuzz
+func Fuzz(data []byte) int {
+
+	l := NewLexer(string(data))
+	p := NewParser(l)
+
+	_, err := p.Parse()
+	if err != nil {
+		return 1
+	}
+
+	return 0
+}

--- a/internal/ql/lexer.go
+++ b/internal/ql/lexer.go
@@ -1,0 +1,141 @@
+package ql
+
+import "strings"
+
+const (
+	// MaxStringSize sets an upper bound on lengths of strings to be parsed
+	MaxStringSize = 256
+)
+
+type Lexer struct {
+	input        string
+	position     int
+	readPosition int
+	ch           byte
+}
+
+// NewLexer creates a new lexer instance.
+func NewLexer(input string) *Lexer {
+	l := &Lexer{
+		input: input,
+	}
+	l.readChar()
+	return l
+}
+
+// NextToken parses and returns the next token.
+func (l *Lexer) NextToken() Token {
+	var tok Token
+
+	l.skipWhitespace()
+
+	switch l.ch {
+	case ':':
+		tok = NewToken(ASSIGN, l.ch)
+	case ',':
+		tok = NewToken(COMMA, l.ch)
+	case '=':
+		tok = NewToken(EQUAL, l.ch)
+	case '+':
+		tok = NewToken(GREATERTHAN, l.ch)
+	case '-':
+		tok = NewToken(LESSERTHAN, l.ch)
+	case '"':
+		tok.Type = STRING
+		tok.Literal = Literal(l.readString())
+	case '[':
+		tok = NewToken(LBRACKET, l.ch)
+	case ']':
+		tok = NewToken(RBRACKET, l.ch)
+	case 0:
+		tok.Literal = ""
+		tok.Type = EOF
+	default:
+		if isLetter(l.ch) {
+			tok.Literal = Literal(l.readIdentifier())
+			tok.Type = LookupIdent(string(tok.Literal))
+			return tok
+		} else if isDigit(l.ch) {
+			tok.Type = INT
+			tok.Literal = Literal(l.readNumber())
+		} else {
+			tok = NewToken(ILLEGAL, l.ch)
+		}
+	}
+	l.readChar()
+	return tok
+}
+
+// Lex builds a lexeme slice by iterating and lexing the input.
+func (l *Lexer) Lex() []Token {
+	lexemes := make([]Token, 0)
+	tok := l.NextToken()
+	for tok.Type != EOF {
+		lexemes = append(lexemes, tok)
+		tok = l.NextToken()
+	}
+	return lexemes
+}
+
+// Analyze runs a heuristic search analysis on the lexer output
+// to check for common typos and invalid inputs.
+func (l *Lexer) Analyze() error {
+	return nil
+}
+
+// readChar reads the next character.
+func (l *Lexer) readChar() {
+	if l.readPosition >= len(l.input) {
+		l.ch = 0
+	} else {
+		l.ch = l.input[l.readPosition]
+	}
+	l.position = l.readPosition
+	l.readPosition++
+}
+
+// readIdentifier reads an identifier (rhs value).
+func (l *Lexer) readIdentifier() string {
+	pos := l.position
+	for isLetter(l.ch) || isDigit(l.ch) {
+		l.readChar()
+	}
+	return l.input[pos:l.position]
+}
+
+// readNumber reads a number (rhs value).
+func (l *Lexer) readNumber() string {
+	pos := l.position
+	for isDigit(l.ch) {
+		l.readChar()
+	}
+	// when integers are followed by chars e.g 100kb
+	// the last digit will make read position increment
+	// skipping the 'k' when reading it next
+	// to avoid this we decrement readPos before returning
+	l.readPosition--
+	return l.input[pos:l.position]
+}
+
+// readString reads a quoted string (rhs value).
+func (l *Lexer) readString() string {
+	var sb strings.Builder
+	len := 0
+
+	for {
+		l.readChar()
+		len++
+		if l.ch == '"' || l.ch == 0 || len > MaxStringSize {
+			break
+		}
+		sb.WriteByte(l.ch)
+	}
+	return sb.String()
+}
+
+// skipWhitespace consumes whitespace.
+func (l *Lexer) skipWhitespace() {
+	for isWhitespace(l.ch) {
+		l.readChar()
+	}
+}

--- a/internal/ql/lexer_test.go
+++ b/internal/ql/lexer_test.go
@@ -1,0 +1,371 @@
+package ql
+
+import "testing"
+
+func TestNextToken(t *testing.T) {
+	t.Run("TestNextTokenSingle", func(t *testing.T) {
+		input := `:,+-=`
+
+		tests := []struct {
+			expectedType Type
+			expectedLit  Literal
+		}{
+			{ASSIGN, ":"},
+			{COMMA, ","},
+			{GREATERTHAN, "+"},
+			{LESSERTHAN, "-"},
+			{EQUAL, "="},
+		}
+
+		l := NewLexer(input)
+
+		for i, tt := range tests {
+			tok := l.NextToken()
+			if tok.Type != tt.expectedType {
+				t.Fatalf("tests[%d] - tokenType wrong, expected=%q, got=%q", i, tt.expectedType, tok.Type)
+			}
+			if tok.Literal != tt.expectedLit {
+				t.Fatalf("tests[%d] - tokenLiteral wrong, expected=%q, got=%q", i, tt.expectedLit, tok.Literal)
+			}
+		}
+	})
+	t.Run("TestNextTokenStrings", func(t *testing.T) {
+		input := `name:"winshell.ocx"`
+
+		tests := []struct {
+			expectedType Type
+			expectedLit  Literal
+		}{
+			{NAME, "name"},
+			{ASSIGN, ":"},
+			{STRING, "winshell.ocx"},
+		}
+
+		l := NewLexer(input)
+
+		for i, tt := range tests {
+			tok := l.NextToken()
+			if tok.Type != tt.expectedType {
+				t.Fatalf("tests[%d] - tokenType wrong, expected=%q, got=%q", i, tt.expectedType, tok.Type)
+			}
+			if tok.Literal != tt.expectedLit {
+				t.Fatalf("tests[%d] - tokenLiteral wrong, expected=%q, got=%q", i, tt.expectedLit, tok.Literal)
+			}
+		}
+	})
+	t.Run("TestNextTokenNumber", func(t *testing.T) {
+		input := `-123456789kb,fs:2019`
+
+		tests := []struct {
+			expectedType Type
+			expectedLit  Literal
+		}{
+			{LESSERTHAN, "-"},
+			{INT, "123456789"},
+			{KB, "kb"},
+			{COMMA, ","},
+			{FS, "fs"},
+			{ASSIGN, ":"},
+			{INT, "2019"},
+		}
+
+		l := NewLexer(input)
+
+		for i, tt := range tests {
+			tok := l.NextToken()
+			if tok.Type != tt.expectedType {
+				t.Fatalf("tests[%d] - tokenType wrong, expected=%q, got=%q", i, tt.expectedType, tok.Type)
+			}
+			if tok.Literal != tt.expectedLit {
+				t.Fatalf("tests[%d] - tokenLiteral wrong, expected=%q, got=%q", i, tt.expectedLit, tok.Literal)
+			}
+		}
+	})
+	t.Run("TestNextTokenDate", func(t *testing.T) {
+		input := `fs:+"2009-01-01T19:59:22"`
+
+		tests := []struct {
+			expectedType Type
+			expectedLit  Literal
+		}{
+			{FS, "fs"},
+			{ASSIGN, ":"},
+			{GREATERTHAN, "+"},
+			{STRING, "2009-01-01T19:59:22"},
+		}
+
+		l := NewLexer(input)
+
+		for i, tt := range tests {
+			tok := l.NextToken()
+			if tok.Type != tt.expectedType {
+				t.Fatalf("tests[%d] - tokenType wrong, expected=%q, got=%q", i, tt.expectedType, tok.Type)
+			}
+			if tok.Literal != tt.expectedLit {
+				t.Fatalf("tests[%d] - tokenLiteral wrong, expected=%q, got=%q", i, tt.expectedLit, tok.Literal)
+			}
+		}
+	})
+	t.Run("TestNextTokenFull", func(t *testing.T) {
+		input := `type:pe,size:102mb+,strings:["k40s"],section:".k40s", imports:"crypt32.dll"`
+
+		tests := []struct {
+			expectedType Type
+			expectedLit  Literal
+		}{
+			{TYPE, "type"},
+			{ASSIGN, ":"},
+			{IDENT, "pe"},
+			{COMMA, ","},
+			{SIZE, "size"},
+			{ASSIGN, ":"},
+			{INT, "102"},
+			{MB, "mb"},
+			{GREATERTHAN, "+"},
+			{COMMA, ","},
+			{STRINGS, "strings"},
+			{ASSIGN, ":"},
+			{LBRACKET, "["},
+			{STRING, "k40s"},
+			{RBRACKET, "]"},
+			{COMMA, ","},
+			{SECTION, "section"},
+			{ASSIGN, ":"},
+			{STRING, ".k40s"},
+			{COMMA, ","},
+			{IMPORTS, "imports"},
+			{ASSIGN, ":"},
+			{STRING, "crypt32.dll"},
+		}
+
+		l := NewLexer(input)
+
+		for i, tt := range tests {
+			tok := l.NextToken()
+			if tok.Type != tt.expectedType {
+				t.Fatalf("tests[%d] - tokenType wrong, expected=%q, got=%q", i, tt.expectedType, tok.Type)
+			}
+			if tok.Literal != tt.expectedLit {
+				t.Fatalf("tests[%d] - tokenLiteral wrong, expected=%q, got=%q", i, tt.expectedLit, tok.Literal)
+			}
+		}
+	})
+	t.Run("TestNextTokenPartial", func(t *testing.T) {
+		input := `type:pe,size:102mb+,strings:["k40s",".elf",".asm",".code"],positives:+5`
+
+		tests := []struct {
+			expectedType Type
+			expectedLit  Literal
+		}{
+			{TYPE, "type"},
+			{ASSIGN, ":"},
+			{IDENT, "pe"},
+			{COMMA, ","},
+			{SIZE, "size"},
+			{ASSIGN, ":"},
+			{INT, "102"},
+			{MB, "mb"},
+			{GREATERTHAN, "+"},
+			{COMMA, ","},
+			{STRINGS, "strings"},
+			{ASSIGN, ":"},
+			{LBRACKET, "["},
+			{STRING, "k40s"},
+			{COMMA, ","},
+			{STRING, ".elf"},
+			{COMMA, ","},
+			{STRING, ".asm"},
+			{COMMA, ","},
+			{STRING, ".code"},
+			{RBRACKET, "]"},
+			{COMMA, ","},
+			{POSITIVES, "positives"},
+			{ASSIGN, ":"},
+			{GREATERTHAN, "+"},
+			{INT, "5"},
+		}
+
+		l := NewLexer(input)
+
+		for i, tt := range tests {
+			tok := l.NextToken()
+			if tok.Type != tt.expectedType {
+				t.Fatalf("tests[%d] - tokenType wrong, expected=%q, got=%q", i, tt.expectedType, tok.Type)
+			}
+			if tok.Literal != tt.expectedLit {
+				t.Fatalf("tests[%d] - tokenLiteral wrong, expected=%q, got=%q", i, tt.expectedLit, tok.Literal)
+			}
+		}
+	})
+	t.Run("TestNextTokenIllegal", func(t *testing.T) {
+		input := `!??_`
+
+		tests := []struct {
+			expectedType Type
+			expectedLit  Literal
+		}{
+			{ILLEGAL, "!"},
+			{ILLEGAL, "?"},
+			{ILLEGAL, "?"},
+			{ILLEGAL, "_"},
+		}
+
+		l := NewLexer(input)
+
+		for i, tt := range tests {
+			tok := l.NextToken()
+			if tok.Type != tt.expectedType {
+				t.Fatalf("tests[%d] - tokenType wrong, expected=%q, got=%q", i, tt.expectedType, tok.Type)
+			}
+			if tok.Literal != tt.expectedLit {
+				t.Fatalf("tests[%d] - tokenLiteral wrong, expected=%q, got=%q", i, tt.expectedLit, tok.Literal)
+			}
+		}
+	})
+	t.Run("TestLexSingle", func(t *testing.T) {
+		input := `:,+-=`
+
+		expectedTokens := []Token{
+			{ASSIGN, ":"},
+			{COMMA, ","},
+			{GREATERTHAN, "+"},
+			{LESSERTHAN, "-"},
+			{EQUAL, "="},
+		}
+
+		l := NewLexer(input)
+		tokens := l.Lex()
+
+		for i, tok := range expectedTokens {
+			if tokens[i].Type != tok.Type {
+				t.Fatalf("tests[%d] - tokenType wrong, expected=%q, got=%q", i, tok.Type, tokens[i].Type)
+			}
+			if tokens[i].Literal != tok.Literal {
+				t.Fatalf("tests[%d] - tokenLiteral wrong, expected=%q, got=%q", i, tok.Literal, tokens[i].Literal)
+			}
+		}
+	})
+	t.Run("TestLexStrings", func(t *testing.T) {
+		input := `name:"winshell.ocx"`
+
+		expectedTokens := []Token{
+			{NAME, "name"},
+			{ASSIGN, ":"},
+			{STRING, "winshell.ocx"},
+		}
+
+		l := NewLexer(input)
+		tokens := l.Lex()
+
+		for i, tok := range expectedTokens {
+			if tokens[i].Type != tok.Type {
+				t.Fatalf("tests[%d] - tokenType wrong, expected=%q, got=%q", i, tok.Type, tokens[i].Type)
+			}
+			if tokens[i].Literal != tok.Literal {
+				t.Fatalf("tests[%d] - tokenLiteral wrong, expected=%q, got=%q", i, tok.Literal, tokens[i].Literal)
+			}
+		}
+	})
+	t.Run("TestLexNumbers", func(t *testing.T) {
+		input := `-123456789kb,fs:2019`
+
+		expectedTokens := []Token{
+			{LESSERTHAN, "-"},
+			{INT, "123456789"},
+			{KB, "kb"},
+			{COMMA, ","},
+			{FS, "fs"},
+			{ASSIGN, ":"},
+			{INT, "2019"},
+		}
+
+		l := NewLexer(input)
+		tokens := l.Lex()
+
+		for i, tok := range expectedTokens {
+			if tokens[i].Type != tok.Type {
+				t.Fatalf("tests[%d] - tokenType wrong, expected=%q, got=%q", i, tok.Type, tokens[i].Type)
+			}
+			if tokens[i].Literal != tok.Literal {
+				t.Fatalf("tests[%d] - tokenLiteral wrong, expected=%q, got=%q", i, tok.Literal, tokens[i].Literal)
+			}
+		}
+	})
+	t.Run("TestLexFull", func(t *testing.T) {
+		input := `type:pe,size:500kb-,strings:["k40s",".elf",".asm",".code"],positives:+5`
+
+		expectedTokens := []Token{
+			{TYPE, "type"},
+			{ASSIGN, ":"},
+			{IDENT, "pe"},
+			{COMMA, ","},
+			{SIZE, "size"},
+			{ASSIGN, ":"},
+			{INT, "500"},
+			{KB, "kb"},
+			{LESSERTHAN, "-"},
+			{COMMA, ","},
+			{STRINGS, "strings"},
+			{ASSIGN, ":"},
+			{LBRACKET, "["},
+			{STRING, "k40s"},
+			{COMMA, ","},
+			{STRING, ".elf"},
+			{COMMA, ","},
+			{STRING, ".asm"},
+			{COMMA, ","},
+			{STRING, ".code"},
+			{RBRACKET, "]"},
+			{COMMA, ","},
+			{POSITIVES, "positives"},
+			{ASSIGN, ":"},
+			{GREATERTHAN, "+"},
+			{INT, "5"},
+		}
+
+		l := NewLexer(input)
+		tokens := l.Lex()
+
+		for i, tok := range expectedTokens {
+			if tokens[i].Type != tok.Type {
+				t.Fatalf("tests[%d] - tokenType wrong, expected=%q, got=%q", i, tok.Type, tokens[i].Type)
+			}
+			if tokens[i].Literal != tok.Literal {
+				t.Fatalf("tests[%d] - tokenLiteral wrong, expected=%q, got=%q", i, tok.Literal, tokens[i].Literal)
+			}
+		}
+	})
+	t.Run("TestLexPartial", func(t *testing.T) {
+		input := `type:pe,  size:102mb+,strings:["k40s"]`
+
+		expectedTokens := []Token{
+			{TYPE, "type"},
+			{ASSIGN, ":"},
+			{IDENT, "pe"},
+			{COMMA, ","},
+			{SIZE, "size"},
+			{ASSIGN, ":"},
+			{INT, "102"},
+			{MB, "mb"},
+			{GREATERTHAN, "+"},
+			{COMMA, ","},
+			{STRINGS, "strings"},
+			{ASSIGN, ":"},
+			{LBRACKET, "["},
+			{STRING, "k40s"},
+			{RBRACKET, "]"},
+		}
+
+		l := NewLexer(input)
+		tokens := l.Lex()
+
+		for i, tok := range expectedTokens {
+			if tokens[i].Type != tok.Type {
+				t.Fatalf("tests[%d] - tokenType wrong, expected=%q, got=%q", i, tok.Type, tokens[i].Type)
+			}
+			if tokens[i].Literal != tok.Literal {
+				t.Fatalf("tests[%d] - tokenLiteral wrong, expected=%q, got=%q", i, tok.Literal, tokens[i].Literal)
+			}
+		}
+	})
+}

--- a/internal/ql/parser.go
+++ b/internal/ql/parser.go
@@ -1,0 +1,282 @@
+package ql
+
+import (
+	"errors"
+)
+
+var (
+	// errors
+	errBadQuerySyntax error = errors.New("bad query syntax")
+	// empty return types
+	emptySingleQuery = SingleQuery{}
+)
+
+// Parser implements a Pratt recursive descent parser.
+type Parser struct {
+	l *Lexer
+
+	currToken Token
+	peekToken Token
+}
+
+// NewParser creates a new instance of the parser.
+func NewParser(l *Lexer) *Parser {
+	p := &Parser{
+		l: l,
+	}
+	p.NextToken()
+	p.NextToken()
+	return p
+}
+
+// NextToken reads the next token in the lexemes.
+func (p *Parser) NextToken() {
+	p.currToken = p.peekToken
+	p.peekToken = p.l.NextToken()
+}
+
+// Parse the lexems in the search query.
+func (p *Parser) Parse() (SearchQuery, error) {
+	query := SearchQuery{}
+	query.Statements = make([]QueryStatement, 0)
+
+	for p.currToken.Type != EOF {
+		q, err := p.ParseQuery()
+		if err != nil {
+			return query, err
+		}
+		if q != nil {
+			query.Statements = append(query.Statements, q)
+		}
+		p.NextToken()
+	}
+	return query, nil
+}
+
+// ParseQuery will parse a given query type (filetype,filesize,datetimes..,)
+// and return the query statement.
+func (p *Parser) ParseQuery() (QueryStatement, error) {
+	switch p.currToken.Type {
+	case SIZE:
+		return p.parseFileSizeQuery()
+	case TYPE:
+		return p.parseFileTypeQuery()
+	case LS:
+		return p.parseDatetimeQuery()
+	case FS:
+		return p.parseDatetimeQuery()
+	case POSITIVES:
+		return p.parsePositivesQuery()
+	case SECTION:
+		return p.parseSectionQuery()
+	case IMPORTS:
+		return p.parseImportsQuery()
+	case EXPORTS:
+		return p.parseExportsQuery()
+	default:
+		return nil, errBadQuerySyntax
+	}
+}
+
+// parseFileSizeQuery parses size queries by including the range
+// and transforming filesizes from KB or MB to Bytes.
+func (p *Parser) parseFileSizeQuery() (SingleQuery, error) {
+	query := SingleQuery{
+		Token: p.currToken,
+		Op:    EQUAL,
+	}
+	// we expect an assignment (:) next
+	if !p.expectPeek(ASSIGN) {
+		return emptySingleQuery, newSyntaxError(SIZE, ASSIGN, string(p.peekToken.Type))
+	}
+	// we expect a digit next
+	if !p.expectPeek(INT) {
+		return emptySingleQuery, newSyntaxError(SIZE, INT, string(p.peekToken.Type))
+	}
+	// query value is number
+	query.Value = string(p.currToken.Literal)
+	// if peek token is EOF for e.g `size:200`
+	// then return early
+	if p.expectPeek(EOF) {
+		return query, nil
+	}
+	// if not EOF i.e `size:200+` or `size:1mb-`
+	// then we need to process more
+	// we expect +/- or mb/kb or EOF
+	if !p.expectPeek(GREATERTHAN) && !p.expectPeek(LESSERTHAN) && !p.expectPeek(KB) && !p.expectPeek(MB) {
+		return emptySingleQuery, newSyntaxError(SIZE, "one of [+,-,kb,mb]", string(p.peekToken.Type))
+	}
+	// At this point current token is either KB/MB or +/-
+	// e.g `size:200+` => not KB/MB conversion only operation changes
+	// also implies after the Op (+/-) we expect EOF
+	switch p.currToken.Type {
+	case KB:
+		query.Value = kbToBytesStr(query.Value)
+	case MB:
+		query.Value = mbToBytesStr(query.Value)
+	case GREATERTHAN:
+		query.Op = GREATERTHAN
+	case LESSERTHAN:
+		query.Op = LESSERTHAN
+	}
+	// if previously we had KB/MB then next we expect either +/- or EOF
+	switch p.peekToken.Type {
+	case GREATERTHAN:
+		query.Op = GREATERTHAN
+	case LESSERTHAN:
+		query.Op = LESSERTHAN
+	}
+	for !p.currTokenIs(EOF) && !p.currTokenIs(COMMA) {
+		p.NextToken()
+	}
+	return query, nil
+}
+
+// parseFileTypeQuery parses filetype queries.
+func (p *Parser) parseFileTypeQuery() (SingleQuery, error) {
+	query := SingleQuery{
+		Token: p.currToken,
+		Op:    EQUAL,
+	}
+	if !p.expectPeek(ASSIGN) {
+		return emptySingleQuery, newSyntaxError(TYPE, ASSIGN, string(p.peekToken.Type))
+	}
+	if !p.expectPeek(IDENT) {
+		return emptySingleQuery, newSyntaxError(TYPE, IDENT, string(p.peekToken.Type))
+	}
+	query.Value = string(p.currToken.Literal)
+	for !p.currTokenIs(EOF) && !p.currTokenIs(COMMA) {
+		p.NextToken()
+	}
+	return query, nil
+}
+
+// parsePositivesQuery parses av positives queries.
+func (p *Parser) parsePositivesQuery() (SingleQuery, error) {
+	query := SingleQuery{
+		Token: p.currToken,
+		Op:    EQUAL,
+	}
+	if !p.expectPeek(ASSIGN) {
+		return emptySingleQuery, newSyntaxError(POSITIVES, ASSIGN, string(p.peekToken.Type))
+	}
+	if !p.expectPeek(INT) {
+		return emptySingleQuery, newSyntaxError(POSITIVES, INT, string(p.peekToken.Type))
+	}
+	query.Value = string(p.currToken.Literal)
+
+	switch p.peekToken.Type {
+	case GREATERTHAN:
+		query.Op = GREATERTHAN
+	case LESSERTHAN:
+		query.Op = LESSERTHAN
+	}
+
+	for !p.currTokenIs(EOF) && !p.currTokenIs(COMMA) {
+		p.NextToken()
+	}
+	return query, nil
+}
+
+// parseDatetimeQuery parses datetime queries
+// such as last_seen, first_seen.
+func (p *Parser) parseDatetimeQuery() (SingleQuery, error) {
+	query := SingleQuery{
+		Token: p.currToken,
+		Op:    EQUAL,
+	}
+	if !p.expectPeek(ASSIGN) {
+		return emptySingleQuery, newSyntaxError("DATE", ASSIGN, string(p.peekToken.Type))
+	}
+	if !p.expectPeek(STRING) {
+		return emptySingleQuery, newSyntaxError("DATE", STRING, string(p.peekToken.Type))
+	}
+	query.Value = string(p.currToken.Literal)
+	for !p.currTokenIs(EOF) && !p.currTokenIs(COMMA) {
+		p.NextToken()
+	}
+	return query, nil
+}
+
+// TODO: parseStringsQuery parses strings queries.
+func (p *Parser) parseStringsQuery() (SingleQuery, error) {
+	return emptySingleQuery, nil
+}
+
+// parseSectionQuery parses SECTION queries.
+func (p *Parser) parseSectionQuery() (SingleQuery, error) {
+	query := SingleQuery{
+		Token: p.currToken,
+		Op:    EQUAL,
+	}
+	if !p.expectPeek(ASSIGN) {
+		return emptySingleQuery, newSyntaxError(SECTION, ASSIGN, string(p.peekToken.Type))
+	}
+	if !p.expectPeek(STRING) {
+		return emptySingleQuery, newSyntaxError(SECTION, STRING, string(p.peekToken.Type))
+	}
+	query.Value = string(p.currToken.Literal)
+	for !p.currTokenIs(EOF) && !p.currTokenIs(COMMA) {
+		p.NextToken()
+	}
+	return query, nil
+}
+
+// parseImportsQuery parses IMPORTS queries.
+func (p *Parser) parseImportsQuery() (SingleQuery, error) {
+	query := SingleQuery{
+		Token: p.currToken,
+		Op:    EQUAL,
+	}
+	if !p.expectPeek(ASSIGN) {
+		return emptySingleQuery, newSyntaxError(IMPORTS, ASSIGN, string(p.peekToken.Type))
+	}
+	if !p.expectPeek(STRING) {
+		return emptySingleQuery, newSyntaxError(IMPORTS, STRING, string(p.peekToken.Type))
+	}
+	query.Value = string(p.currToken.Literal)
+	for !p.currTokenIs(EOF) && !p.currTokenIs(COMMA) {
+		p.NextToken()
+	}
+	return query, nil
+}
+
+// parseExportsQuery parses EXPORTS queries.
+func (p *Parser) parseExportsQuery() (SingleQuery, error) {
+	query := SingleQuery{
+		Token: p.currToken,
+		Op:    EQUAL,
+	}
+	if !p.expectPeek(ASSIGN) {
+		return emptySingleQuery, newSyntaxError(EXPORTS, ASSIGN, string(p.peekToken.Type))
+	}
+	if !p.expectPeek(STRING) {
+		return emptySingleQuery, newSyntaxError(EXPORTS, STRING, string(p.peekToken.Type))
+	}
+	query.Value = string(p.currToken.Literal)
+	for !p.currTokenIs(EOF) && !p.currTokenIs(COMMA) {
+		p.NextToken()
+	}
+	return query, nil
+}
+
+// parseFileTypeQuery parses
+// currTokenIs asserts the current token type.
+func (p *Parser) currTokenIs(t Type) bool {
+	return p.currToken.Type == t
+}
+
+// peekTokenIs asserts the next token type.
+func (p *Parser) peekTokenIs(t Type) bool {
+	return p.peekToken.Type == t
+}
+
+// expectPeek returns true or false depending on whether the next
+// token is the expected one.
+func (p *Parser) expectPeek(t Type) bool {
+	if p.peekTokenIs(t) {
+		p.NextToken()
+		return true
+	}
+	return false
+}

--- a/internal/ql/parser_test.go
+++ b/internal/ql/parser_test.go
@@ -1,0 +1,700 @@
+package ql
+
+import (
+	"testing"
+)
+
+func TestParser(t *testing.T) {
+	t.Run("TestParseFileSizeQuery", func(t *testing.T) {
+		tests := []struct {
+			input         string
+			expectedQuery SingleQuery
+		}{
+			{
+				input: `size:100kb+`,
+				expectedQuery: SingleQuery{
+					Token{
+						SIZE,
+						"size",
+					},
+					GREATERTHAN,
+					"100000",
+				},
+			}, {
+				input: `size:1mb-`,
+				expectedQuery: SingleQuery{
+					Token{
+						SIZE,
+						"size",
+					},
+					LESSERTHAN,
+					"1000000",
+				},
+			}, {
+				input: `size:250kb`,
+				expectedQuery: SingleQuery{
+					Token{
+						SIZE,
+						"size",
+					},
+					EQUAL,
+					"250000",
+				},
+			}, {
+				input: `size:500+`,
+				expectedQuery: SingleQuery{
+					Token{
+						SIZE,
+						"size",
+					},
+					GREATERTHAN,
+					"500",
+				},
+			}, {
+				input: `size:200`,
+				expectedQuery: SingleQuery{
+					Token{
+						SIZE,
+						"size",
+					},
+					EQUAL,
+					"200",
+				},
+			}, {
+				input: `size:200kb-`,
+				expectedQuery: SingleQuery{
+					Token{
+						SIZE,
+						"size",
+					},
+					LESSERTHAN,
+					"200000",
+				},
+			},
+		}
+
+		for i, tt := range tests {
+			l := NewLexer(tt.input)
+			p := NewParser(l)
+			query, err := p.parseFileSizeQuery()
+			if err != nil {
+				t.Fatalf("test[%d] failed with error :%q", i, err)
+			}
+			if query.Token != tt.expectedQuery.Token {
+				t.Fatalf("test[%d] expected token=%q got token=%q", i, tt.expectedQuery.Token, query.Token)
+			} else if query.Value != tt.expectedQuery.Value {
+				t.Fatalf("test[%d] expected value=%q got value=%q", i, tt.expectedQuery.Value, query.Value)
+			} else if query.Op != tt.expectedQuery.Op {
+				t.Fatalf("test[%d]=%s expected op=%q got op=%q", i, tt.input, tt.expectedQuery.Op, query.Op)
+			}
+
+		}
+	})
+	t.Run("TestParseFileTypeQuery", func(t *testing.T) {
+		tests := []struct {
+			input         string
+			expectedQuery SingleQuery
+		}{
+			{
+				input: `type:pe`,
+				expectedQuery: SingleQuery{
+					Token{
+						TYPE,
+						"type",
+					},
+					EQUAL,
+					"pe",
+				},
+			}, {
+				input: `type:pedll`,
+				expectedQuery: SingleQuery{
+					Token{
+						TYPE,
+						"type",
+					},
+					EQUAL,
+					"pedll",
+				},
+			}, {
+				input: `type:elf`,
+				expectedQuery: SingleQuery{
+					Token{
+						TYPE,
+						"type",
+					},
+					EQUAL,
+					"elf",
+				},
+			},
+		}
+
+		for i, tt := range tests {
+			l := NewLexer(tt.input)
+			p := NewParser(l)
+			query, err := p.parseFileTypeQuery()
+			if err != nil {
+				t.Fatalf("test[%d] failed with error :%q", i, err)
+			}
+			if query.Token != tt.expectedQuery.Token {
+				t.Fatalf("test[%d] expected token=%q got token=%q", i, tt.expectedQuery.Token, query.Token)
+			} else if query.Value != tt.expectedQuery.Value {
+				t.Fatalf("test[%d] expected value=%q got value=%q", i, tt.expectedQuery.Value, query.Value)
+			} else if query.Op != tt.expectedQuery.Op {
+				t.Fatalf("test[%d] expected op=%q got op=%q", i, tt.expectedQuery.Op, query.Op)
+			}
+		}
+	})
+	t.Run("TestParseDatetimeQuery", func(t *testing.T) {
+		tests := []struct {
+			input         string
+			expectedQuery SingleQuery
+		}{
+			{
+				input: `ls:"2009-01-01T19:59:22"`,
+				expectedQuery: SingleQuery{
+					Token{
+						LS,
+						"ls",
+					},
+					EQUAL,
+					"2009-01-01T19:59:22",
+				},
+			}, {
+				input: `fs:"2012-08-2116:00:00"`,
+				expectedQuery: SingleQuery{
+					Token{
+						FS,
+						"fs",
+					},
+					EQUAL,
+					"2012-08-2116:00:00",
+				},
+			}, {
+				input: `fs:"2012-08-2116:59:22"`,
+				expectedQuery: SingleQuery{
+					Token{
+						FS,
+						"fs",
+					},
+					EQUAL,
+					"2012-08-2116:59:22",
+				},
+			},
+		}
+
+		for i, tt := range tests {
+			l := NewLexer(tt.input)
+			p := NewParser(l)
+			query, err := p.parseDatetimeQuery()
+			if err != nil {
+				t.Fatalf("test[%d] failed with error :%q", i, err)
+			}
+			if query.Token != tt.expectedQuery.Token {
+				t.Fatalf("test[%d] expected token=%q got token=%q", i, tt.expectedQuery.Token, query.Token)
+			} else if query.Value != tt.expectedQuery.Value {
+				t.Fatalf("test[%d] expected value=%q got value=%q", i, tt.expectedQuery.Value, query.Value)
+			} else if query.Op != tt.expectedQuery.Op {
+				t.Fatalf("test[%d] expected op=%q got op=%q", i, tt.expectedQuery.Op, query.Op)
+			}
+		}
+	})
+	t.Run("TestParsePositivesQuery", func(t *testing.T) {
+		tests := []struct {
+			input         string
+			expectedQuery SingleQuery
+		}{
+			{
+				input: `positives:5`,
+				expectedQuery: SingleQuery{
+					Token{
+						POSITIVES,
+						"positives",
+					},
+					EQUAL,
+					"5",
+				},
+			}, {
+				input: `positives:10+`,
+				expectedQuery: SingleQuery{
+					Token{
+						POSITIVES,
+						"positives",
+					},
+					GREATERTHAN,
+					"10",
+				},
+			},
+		}
+
+		for i, tt := range tests {
+			l := NewLexer(tt.input)
+			p := NewParser(l)
+			query, err := p.parsePositivesQuery()
+			if err != nil {
+				t.Fatalf("test[%d] failed with error :%q", i, err)
+			}
+			if query.Token != tt.expectedQuery.Token {
+				t.Fatalf("test[%d] expected token=%q got token=%q", i, tt.expectedQuery.Token, query.Token)
+			} else if query.Value != tt.expectedQuery.Value {
+				t.Fatalf("test[%d] expected value=%q got value=%q", i, tt.expectedQuery.Value, query.Value)
+			} else if query.Op != tt.expectedQuery.Op {
+				t.Fatalf("test[%d] expected op=%q got op=%q", i, tt.expectedQuery.Op, query.Op)
+			}
+		}
+	})
+	t.Run("TestParseSimpleQuery", func(t *testing.T) {
+		tests := []struct {
+			input         string
+			expectedQuery SingleQuery
+		}{
+			{
+				input: `type:peexe`,
+				expectedQuery: SingleQuery{
+					Token{
+						TYPE,
+						"type",
+					},
+					EQUAL,
+					"peexe",
+				},
+			}, {
+				input: `size:200kb+`,
+				expectedQuery: SingleQuery{
+					Token{
+						SIZE,
+						"size",
+					},
+					GREATERTHAN,
+					"200000",
+				},
+			}, {
+				input: `size:1mb-`,
+				expectedQuery: SingleQuery{
+					Token{
+						SIZE,
+						"size",
+					},
+					LESSERTHAN,
+					"1000000",
+				},
+			}, {
+				input: `size:2mb-,`,
+				expectedQuery: SingleQuery{
+					Token{
+						SIZE,
+						"size",
+					},
+					LESSERTHAN,
+					"2000000",
+				},
+			}, {
+				input: `ls:"2009-01-01T19:59:22"`,
+				expectedQuery: SingleQuery{
+					Token{
+						LS,
+						"ls",
+					},
+					EQUAL,
+					"2009-01-01T19:59:22",
+				},
+			}, {
+				input: `fs:"2012-08-2116:00:00"`,
+				expectedQuery: SingleQuery{
+					Token{
+						FS,
+						"fs",
+					},
+					EQUAL,
+					"2012-08-2116:00:00",
+				},
+			}, {
+				input: `fs:"2012-08-2116:59:22"`,
+				expectedQuery: SingleQuery{
+					Token{
+						FS,
+						"fs",
+					},
+					EQUAL,
+					"2012-08-2116:59:22",
+				},
+			}, {
+				input: `positives:5`,
+				expectedQuery: SingleQuery{
+					Token{
+						POSITIVES,
+						"positives",
+					},
+					EQUAL,
+					"5",
+				},
+			}, {
+				input: `positives:10+`,
+				expectedQuery: SingleQuery{
+					Token{
+						POSITIVES,
+						"positives",
+					},
+					GREATERTHAN,
+					"10",
+				},
+			}, {
+				input: `section:".k40s"`,
+				expectedQuery: SingleQuery{
+					Token{
+						SECTION,
+						"section",
+					},
+					EQUAL,
+					".k40s",
+				},
+			}, {
+				input: `imports:"crypt32.dll"`,
+				expectedQuery: SingleQuery{
+					Token{
+						IMPORTS,
+						"imports",
+					},
+					EQUAL,
+					"crypt32.dll",
+				},
+			}, {
+				input: `exports:"rtEncryptFolder"`,
+				expectedQuery: SingleQuery{
+					Token{
+						EXPORTS,
+						"exports",
+					},
+					EQUAL,
+					"rtEncryptFolder",
+				},
+			},
+		}
+
+		for i, tt := range tests {
+			l := NewLexer(tt.input)
+			p := NewParser(l)
+			queries, err := p.Parse()
+			if err != nil {
+				t.Fatalf("test[%d] failed with error=%q :", i, err)
+			}
+			for _, q := range queries.Statements {
+				query := q.(SingleQuery)
+				if query.Token != tt.expectedQuery.Token {
+					t.Fatalf("test[%d] expected token=%q got token=%q", i, tt.expectedQuery.Token, query.Token)
+				} else if query.Value != tt.expectedQuery.Value {
+					t.Fatalf("test[%d] expected value=%q got value=%q", i, tt.expectedQuery.Value, query.Value)
+				} else if query.Op != tt.expectedQuery.Op {
+					t.Fatalf("test[%d] expected op=%q got op=%q", i, tt.expectedQuery.Op, query.Op)
+				}
+			}
+		}
+	})
+	t.Run("TestParseMultiQuery", func(t *testing.T) {
+		tests := []struct {
+			input         string
+			expectedQuery []SingleQuery
+		}{
+			{
+				input: `type:peexe,size:200kb+`,
+				expectedQuery: []SingleQuery{
+					{
+						Token{
+							TYPE,
+							"type",
+						},
+						EQUAL,
+						"peexe",
+					},
+					{
+						Token{
+							SIZE,
+							"size",
+						},
+						GREATERTHAN,
+						"200000",
+					},
+				},
+			}, {
+				input: `type:elf,positives:30+,size:200kb+`,
+				expectedQuery: []SingleQuery{
+					{
+						Token{
+							TYPE,
+							"type",
+						},
+						EQUAL,
+						"elf",
+					}, {
+						Token{
+							POSITIVES,
+							"positives",
+						},
+						GREATERTHAN,
+						"30",
+					}, {
+						Token{
+							SIZE,
+							"size",
+						},
+						GREATERTHAN,
+						"200000",
+					},
+				},
+			},
+		}
+
+		for i, tt := range tests {
+			l := NewLexer(tt.input)
+			p := NewParser(l)
+			queries, err := p.Parse()
+			if err != nil {
+				t.Fatalf("test[%d] failed with error=%q :", i, err)
+			}
+			t.Log(queries)
+			for k, q := range queries.Statements {
+				query := q.(SingleQuery)
+				t.Log(query)
+				if query != tt.expectedQuery[k] {
+					t.Fatalf("test[%d] failed expected=%q got=%q ", k, tt.expectedQuery[k], query)
+				}
+			}
+		}
+	})
+}
+
+func TestParserFailure(t *testing.T) {
+	t.Run("TestParseFileSizeQueryWithError", func(t *testing.T) {
+		tests := []struct {
+			input         string
+			err           error
+			expectedQuery SingleQuery
+		}{
+			{
+				input:         `size,:100`,
+				expectedQuery: emptySingleQuery,
+				err:           newSyntaxError(SIZE, ASSIGN, COMMA),
+			}, {
+				input:         `size:a100`,
+				expectedQuery: emptySingleQuery,
+				err:           newSyntaxError(SIZE, INT, IDENT),
+			}, {
+				input:         `size:250,kb`,
+				expectedQuery: emptySingleQuery,
+				err:           newSyntaxError(SIZE, "one of [+,-,kb,mb]", COMMA),
+			},
+		}
+
+		for i, tt := range tests {
+			l := NewLexer(tt.input)
+			p := NewParser(l)
+			query, err := p.parseFileSizeQuery()
+			if err == nil {
+				t.Fatalf("test[%d] expected failure with error :%q got nil", i, tt.err)
+			}
+			if err.Error() != tt.err.Error() {
+				t.Fatalf("test[%d] expected error to be :%q got %q", i, tt.err, err)
+			}
+			if query != emptySingleQuery {
+				t.Fatalf("test[%d] expected empty query :%q got %q", i, emptySingleQuery, query)
+			}
+		}
+	})
+	t.Run("TestParseFileTypeQueryWithError", func(t *testing.T) {
+		tests := []struct {
+			input         string
+			err           error
+			expectedQuery SingleQuery
+		}{
+			{
+				input:         `type,:pe`,
+				expectedQuery: emptySingleQuery,
+				err:           newSyntaxError(TYPE, ASSIGN, COMMA),
+			}, {
+				input:         `type:12`,
+				expectedQuery: emptySingleQuery,
+				err:           newSyntaxError(TYPE, IDENT, INT),
+			}, {
+				input:         `type:,pe`,
+				expectedQuery: emptySingleQuery,
+				err:           newSyntaxError(TYPE, IDENT, COMMA),
+			},
+		}
+
+		for i, tt := range tests {
+			l := NewLexer(tt.input)
+			p := NewParser(l)
+			query, err := p.parseFileTypeQuery()
+			if err == nil {
+				t.Fatalf("test[%d] expected failure with error :%q got nil", i, tt.err)
+			}
+			if err.Error() != tt.err.Error() {
+				t.Fatalf("test[%d] expected error to be :%q got %q", i, tt.err, err)
+			}
+			if query != emptySingleQuery {
+				t.Fatalf("test[%d] expected empty query :%q got %q", i, emptySingleQuery, query)
+			}
+		}
+	})
+	t.Run("TestParseDatetimeQueryWithError", func(t *testing.T) {
+		tests := []struct {
+			input         string
+			err           error
+			expectedQuery SingleQuery
+		}{
+			{
+				input:         `fs,:"2012-08-2116:59:22"`,
+				expectedQuery: emptySingleQuery,
+				err:           newSyntaxError("DATE", ASSIGN, COMMA),
+			}, {
+				input:         `ls:123"2012-08-2116:59:22"`,
+				expectedQuery: emptySingleQuery,
+				err:           newSyntaxError("DATE", STRING, INT),
+			},
+		}
+
+		for i, tt := range tests {
+			l := NewLexer(tt.input)
+			p := NewParser(l)
+			query, err := p.parseDatetimeQuery()
+			if err == nil {
+				t.Fatalf("test[%d] expected failure with error :%q got nil", i, tt.err)
+			}
+			if err.Error() != tt.err.Error() {
+				t.Fatalf("test[%d] expected error to be :%q got %q", i, tt.err, err)
+			}
+			if query != emptySingleQuery {
+				t.Fatalf("test[%d] expected empty query :%q got %q", i, emptySingleQuery, query)
+			}
+		}
+	})
+	t.Run("TestParseQueryWithError", func(t *testing.T) {
+		tests := []struct {
+			input         string
+			err           error
+			expectedQuery SingleQuery
+		}{
+			{
+				input:         `ano,:pe`,
+				expectedQuery: emptySingleQuery,
+				err:           errBadQuerySyntax,
+			},
+		}
+
+		for i, tt := range tests {
+			l := NewLexer(tt.input)
+			p := NewParser(l)
+			_, err := p.Parse()
+			if err == nil {
+				t.Fatalf("test[%d] expected failure with error :%q got nil", i, tt.err)
+			}
+			if err.Error() != tt.err.Error() {
+				t.Fatalf("test[%d] expected error to be :%q got %q", i, tt.err, err)
+			}
+		}
+	})
+	t.Run("TestParseSectionQueryWithError", func(t *testing.T) {
+		tests := []struct {
+			input         string
+			err           error
+			expectedQuery SingleQuery
+		}{
+			{
+				input:         `section,:".k40s"`,
+				expectedQuery: emptySingleQuery,
+				err:           newSyntaxError(SECTION, ASSIGN, COMMA),
+			}, {
+				input:         `section:23".k40s"`,
+				expectedQuery: emptySingleQuery,
+				err:           newSyntaxError(SECTION, STRING, INT),
+			},
+		}
+
+		for i, tt := range tests {
+			l := NewLexer(tt.input)
+			p := NewParser(l)
+			query, err := p.parseSectionQuery()
+			if err == nil {
+				t.Fatalf("test[%d] expected failure with error :%q got nil", i, tt.err)
+			}
+			if err.Error() != tt.err.Error() {
+				t.Fatalf("test[%d] expected error to be :%q got %q", i, tt.err, err)
+			}
+			if query != emptySingleQuery {
+				t.Fatalf("test[%d] expected empty query :%q got %q", i, emptySingleQuery, query)
+			}
+		}
+	})
+	t.Run("TestParsePositivesQueryWithError", func(t *testing.T) {
+		tests := []struct {
+			input         string
+			err           error
+			expectedQuery SingleQuery
+		}{
+			{
+				input:         `positives,:100`,
+				expectedQuery: emptySingleQuery,
+				err:           newSyntaxError(POSITIVES, ASSIGN, COMMA),
+			}, {
+				input:         `positives:a100`,
+				expectedQuery: emptySingleQuery,
+				err:           newSyntaxError(POSITIVES, INT, IDENT),
+			},
+		}
+
+		for i, tt := range tests {
+			l := NewLexer(tt.input)
+			p := NewParser(l)
+			query, err := p.parsePositivesQuery()
+			if err == nil {
+				t.Fatalf("test[%d] expected failure with error :%q got nil", i, tt.err)
+			}
+			if err.Error() != tt.err.Error() {
+				t.Fatalf("test[%d] expected error to be :%q got %q", i, tt.err, err)
+			}
+			if query != emptySingleQuery {
+				t.Fatalf("test[%d] expected empty query :%q got %q", i, emptySingleQuery, query)
+			}
+		}
+	})
+}
+func BenchmarkParser(b *testing.B) {
+	tests := []struct {
+		input         string
+		expectedQuery []SingleQuery
+	}{
+		{
+			input: `type:elf,positives:30+,size:200kb+`,
+			expectedQuery: []SingleQuery{
+				{
+					Token{
+						TYPE,
+						"type",
+					},
+					EQUAL,
+					"elf",
+				}, {
+					Token{
+						POSITIVES,
+						"positives",
+					},
+					GREATERTHAN,
+					"30",
+				}, {
+					Token{
+						SIZE,
+						"size",
+					},
+					GREATERTHAN,
+					"200000",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		l := NewLexer(tt.input)
+		p := NewParser(l)
+		p.parseFileSizeQuery()
+
+	}
+}

--- a/internal/ql/token.go
+++ b/internal/ql/token.go
@@ -1,0 +1,93 @@
+package ql
+
+// Type defines the support modifiers we want to support in a search query
+type Type string
+
+// Literal encodes a literal value
+type Literal string
+
+// Token represents the actual token holds the type and it's literal representation.
+type Token struct {
+	Type
+	Literal
+}
+
+// New creates a new token instance
+func NewToken(typ Type, ch byte) Token {
+	return Token{
+		Type:    typ,
+		Literal: Literal(ch),
+	}
+}
+
+// keywords defines a map of modifier keywords and their respective tokens.
+var keywords = map[string]Type{
+	"type":      TYPE,
+	"size":      SIZE,
+	"ls":        LS,
+	"fs":        FS,
+	"positives": POSITIVES,
+	"name":      NAME,
+	"strings":   STRINGS,
+	"kb":        KB,
+	"mb":        MB,
+	"section":   SECTION,
+	"imports":   IMPORTS,
+	"exports":   EXPORTS,
+}
+
+const (
+	// Special modifiers
+	ILLEGAL = "ILLEGAL"
+	EOF     = "EOF"
+	WS      = "WS"
+
+	// Literals and Field names (the ones occuring in file.json)
+	IDENT = "IDENTIFIER"
+	// Integers
+	INT = "INT"
+	// Strings
+	STRING = "STRING"
+
+	// Separators
+	COMMA    = ","
+	LBRACKET = "["
+	RBRACKET = "]"
+
+	// Conditionals
+	OR  = "OR"
+	AND = "AND"
+
+	// Value assignement
+	ASSIGN = ":"
+	// Operators
+	EQUAL       = "="
+	GREATERTHAN = "+"
+	LESSERTHAN  = "-"
+
+	// Keywords
+	// Modifiers on all filetypes.
+	TYPE      = "TYPE"
+	SIZE      = "SIZE"
+	LS        = "LS"
+	FS        = "FS"
+	POSITIVES = "POSITIVES"
+	NAME      = "NAME"
+	STRINGS   = "STRINGS"
+	// Modifiers on binary executable formats (PE/ELF/Mach-o)
+	SECTION = "SECTION"
+	IMPORTS = "IMPORTS"
+	EXPORTS = "EXPORTS"
+
+	// Qualifiers
+	KB = "kb"
+	MB = "mb"
+)
+
+// LookupIdent checks a given identifier against the keyword table.
+func LookupIdent(ident string) Type {
+	if tok, ok := keywords[ident]; ok {
+		return tok
+	}
+	return IDENT
+}

--- a/internal/ql/transpiler.go
+++ b/internal/ql/transpiler.go
@@ -1,0 +1,40 @@
+package ql
+
+import "strings"
+
+const (
+	// SELECTFromBucketQuery
+	SELECTFromBucketQuery = "SELECT * FROM bucket WHERE "
+)
+
+// N1QLBuilder implements a query builder for N1QL.
+type N1QLBuilder struct {
+	bucket string
+	fields map[string]string
+	sb     strings.Builder
+}
+
+// NewN1QLBuilder creates a new N1QL builder.
+func NewN1QLBuilder(bucket string) *N1QLBuilder {
+	return &N1QLBuilder{
+		bucket: bucket,
+		fields: make(map[string]string),
+		sb:     strings.Builder{},
+	}
+}
+
+// TranspileSingleQuery transpiles an N1QL query for single queries.
+func (n *N1QLBuilder) TranspileSingleQuery(sq SingleQuery) string {
+	n.sb.Reset()
+	n.sb.WriteString(SELECTFromBucketQuery)
+	switch sq.Type {
+	case SIZE:
+		n.sb.WriteString("size")
+		n.sb.WriteByte(' ')
+		n.sb.WriteString(convOp(sq.Op))
+		n.sb.WriteByte(' ')
+		n.sb.WriteString(sq.Value)
+		return n.sb.String()
+	}
+	return ""
+}

--- a/internal/ql/transpiler_test.go
+++ b/internal/ql/transpiler_test.go
@@ -46,7 +46,6 @@ func TestTranspiler(t *testing.T) {
 					t.Fatalf("test[%d] failed expected %s got %s", i, tt.out, got)
 				}
 			}
-
 		}
 	})
 }

--- a/internal/ql/transpiler_test.go
+++ b/internal/ql/transpiler_test.go
@@ -1,0 +1,52 @@
+package ql
+
+import (
+	"testing"
+)
+
+func TestTranspiler(t *testing.T) {
+	t.Run("TestTranspileSearchQuery", func(t *testing.T) {
+
+		tests := []struct {
+			qType Type
+			in    string
+			out   string
+		}{
+			{
+				qType: SIZE,
+				in:    `size:100kb+`,
+				out:   `SELECT * FROM bucket WHERE size >= 100000`,
+			},
+			{
+				in:  `type:pe`,
+				out: `SELECT * FROM bucket WHERE fileformat = "pe"`,
+			},
+			{
+				in:  `fs:"2012-08-2116:59:22"`,
+				out: `SELECT * FROM bucket WHERE last_seen = 1345568362`,
+			},
+			{
+				in:  `positives:10+`,
+				out: `SELECT * FROM bucket WHERE ARRAY_COUNT ( ARRAY_FLATTEN ( ARRAY i.infected for i in OBJECT_VALUES(multiav.last_scan) WHEN i.infected=true end, 1)) >= 10`,
+			},
+			{
+				in:  `positives:5`,
+				out: `SELECT * FROM bucket WHERE ARRAY_COUNT ( ARRAY_FLATTEN ( ARRAY i.infected for i in OBJECT_VALUES(multiav.last_scan) WHEN i.infected=true end, 1)) = 5`,
+			},
+		}
+		n1bl := NewN1QLBuilder("bucket")
+		for i, tt := range tests {
+			if tt.qType == SIZE {
+				sq, err := NewParser(NewLexer(tt.in)).parseFileSizeQuery()
+				if err != nil {
+					t.Fatalf("test[%d] failed with error:%q", i, err)
+				}
+				got := n1bl.TranspileSingleQuery(sq)
+				if got != tt.out {
+					t.Fatalf("test[%d] failed expected %s got %s", i, tt.out, got)
+				}
+			}
+
+		}
+	})
+}


### PR DESCRIPTION
Move internal query language implementation to monorepo to ease integration with core application later on.